### PR TITLE
reduce default logging volume

### DIFF
--- a/src/agents/quest_agent.py
+++ b/src/agents/quest_agent.py
@@ -56,8 +56,8 @@ class QuestAgent(InterruptiblePythonAgent):
         player = game_state.player
         quest = get_current_quest(context)
 
-        logging.info(
-            "[DEBUG] Running Quest Agent",
+        logging.debug(
+            "Running Quest Agent",
             extra={
                 AgentLogging.IS_MESSAGE: True,
                 AgentLogging.MESSAGE_TYPE: AgentLogging.AGENT,
@@ -70,8 +70,8 @@ class QuestAgent(InterruptiblePythonAgent):
             quest.sent_intro = True
             save_game_state(game_state, context)
 
-            logging.info(
-                "[DEBUG] Sending Intro Part 2",
+            logging.debug(
+                "Sending Intro Part 2",
                 extra={
                     AgentLogging.IS_MESSAGE: True,
                     AgentLogging.MESSAGE_TYPE: AgentLogging.AGENT,
@@ -91,8 +91,8 @@ class QuestAgent(InterruptiblePythonAgent):
 
             save_game_state(game_state, context)
         else:
-            logging.info(
-                "[DEBUG] First Quest Story Block Skipped",
+            logging.debug(
+                "First Quest Story Block Skipped",
                 extra={
                     AgentLogging.IS_MESSAGE: True,
                     AgentLogging.MESSAGE_TYPE: AgentLogging.AGENT,

--- a/src/api.py
+++ b/src/api.py
@@ -208,7 +208,7 @@ class AdventureGameService(AgentService):
         game_state = get_game_state(context)
         active_mode = game_state.active_mode
 
-        logging.info(
+        logging.debug(
             f"Game State: {json.dumps(game_state.dict())}.",
             extra={
                 AgentLogging.IS_MESSAGE: True,

--- a/src/utils/context_utils.py
+++ b/src/utils/context_utils.py
@@ -152,7 +152,7 @@ def get_server_settings(
 
 
 def get_game_state(context: AgentContext) -> Optional["GameState"]:  # noqa: F821
-    logging.info(
+    logging.debug(
         f"Refreshing Game State from workspace {context.client.config.workspace_handle}.",
         extra={
             AgentLogging.IS_MESSAGE: True,
@@ -196,7 +196,7 @@ def get_game_state(context: AgentContext) -> Optional["GameState"]:  # noqa: F82
 def save_game_state(game_state, context: AgentContext):
     """Save GameState to the KeyValue store."""
 
-    logging.info(
+    logging.debug(
         f"Saving Game State from workspace {context.client.config.workspace_handle}.",
         extra={
             AgentLogging.IS_MESSAGE: True,


### PR DESCRIPTION
Moving some debug logs to `logging.debug`. This should reduce `File` operations, and unclutter a bit of the chat history in repl, etc.