### PR TITLE
feat(prompt trimming): add context token size management for prompts

### DIFF
--- a/src/agents/camp_agent.py
+++ b/src/agents/camp_agent.py
@@ -6,7 +6,6 @@ from steamship.agents.schema import AgentContext
 from steamship.agents.schema.message_selectors import MessageWindowMessageSelector
 
 from schema.game_state import GameState
-from tools.start_conversation_tool import StartConversationTool
 from tools.start_quest_tool import StartQuestTool
 from utils.context_utils import get_game_state
 from utils.moderation_utils import is_block_excluded
@@ -34,7 +33,7 @@ class CampAgent(FunctionsBasedAgent):
 
     def __init__(self, **kwargs):
         super().__init__(
-            tools=[StartQuestTool(), StartConversationTool()],
+            tools=[StartQuestTool()],  # , StartConversationTool()],
             message_selector=NonExcludedMessageWindowSelector(k=10),
             **kwargs,
         )

--- a/src/agents/onboarding_agent.py
+++ b/src/agents/onboarding_agent.py
@@ -14,7 +14,7 @@ from utils.context_utils import (
 )
 from utils.interruptible_python_agent import InterruptiblePythonAgent
 from utils.moderation_utils import mark_block_as_excluded
-from utils.tags import CampTag, CharacterTag, StoryContextTag, TagKindExtensions
+from utils.tags import CharacterTag, InstructionsTag, StoryContextTag, TagKindExtensions
 
 
 def _is_allowed_by_moderation(user_input: str, context: AgentContext) -> bool:
@@ -214,40 +214,44 @@ class OnboardingAgent(InterruptiblePythonAgent):
 
         if not game_state.chat_history_for_onboarding_complete:
             # TODO: We could save a lot of round trips by appending all these blocks at once.
-            context.chat_history.append_system_message(
-                text=f"The character's name is {player.name}",
-                tags=[Tag(kind=TagKindExtensions.CHARACTER, name=CharacterTag.NAME)],
+
+            onboarding_message = (
+                f"You are a game master for an online quest game. In this game, players go on "
+                f"multiple quests in order to achieve an overall goal. You will tell the story of "
+                f"each quest. By completing quests, players build progress towards an overall goal. "
+                f"Quests take place in a specific location, involve obstacles that must be overcome "
+                f"throughout the quest, and end with the player having either found an item that will "
+                f"help them in subsequent quests, or having achieved their ultimate goal.\n"
+                f"A player has requested a new game with the following attributes:\n"
+                f"Genre: {game_state.genre}\n"
+                f"Tone: {game_state.tone}\n"
+                f"The player is playing as a character named {game_state.player.name}. "
+                f"{game_state.player.name} has the following background: "
+                f"{game_state.player.background}\n"
+                f"{game_state.player.name}'s overall goal is to: {game_state.player.motivation}."
+                f"Each quest that {game_state.player.name} goes on MUST further them towards that "
+                f"overall goal."
             )
+
             context.chat_history.append_system_message(
-                text=f"{player.name}'s backstory is: {player.background}",
-                tags=[
-                    Tag(kind=TagKindExtensions.CHARACTER, name=CharacterTag.BACKGROUND)
-                ],
-            )
-            context.chat_history.append_system_message(
-                text=f"{player.name}'s motivation is: {player.motivation}",
-                tags=[
-                    Tag(kind=TagKindExtensions.CHARACTER, name=CharacterTag.MOTIVATION)
-                ],
-            )
-            context.chat_history.append_system_message(
-                text=f"{player.name}'s physical description is: {player.description}",
-                tags=[
-                    Tag(kind=TagKindExtensions.CHARACTER, name=CharacterTag.DESCRIPTION)
-                ],
-            )
-            context.chat_history.append_system_message(
-                text=f"The genre of the story is: {game_state.genre}",
+                text=onboarding_message,
                 tags=[
                     Tag(
+                        kind=TagKindExtensions.INSTRUCTIONS,
+                        name=InstructionsTag.ONBOARDING,
+                    ),
+                    Tag(kind=TagKindExtensions.CHARACTER, name=CharacterTag.NAME),
+                    Tag(kind=TagKindExtensions.CHARACTER, name=CharacterTag.BACKGROUND),
+                    Tag(kind=TagKindExtensions.CHARACTER, name=CharacterTag.MOTIVATION),
+                    Tag(
+                        kind=TagKindExtensions.CHARACTER, name=CharacterTag.DESCRIPTION
+                    ),
+                    Tag(
                         kind=TagKindExtensions.STORY_CONTEXT, name=StoryContextTag.GENRE
-                    )
-                ],
-            )
-            context.chat_history.append_system_message(
-                text=f"The tone of the story is: {game_state.tone}",
-                tags=[
-                    Tag(kind=TagKindExtensions.STORY_CONTEXT, name=StoryContextTag.TONE)
+                    ),
+                    Tag(
+                        kind=TagKindExtensions.STORY_CONTEXT, name=StoryContextTag.TONE
+                    ),
                 ],
             )
             game_state.chat_history_for_onboarding_complete = True

--- a/src/agents/quest_agent.py
+++ b/src/agents/quest_agent.py
@@ -1,7 +1,7 @@
 import json
 import logging
 from datetime import datetime, timezone
-from random import random
+from random import randint, random
 from typing import List
 
 from steamship import Tag
@@ -14,19 +14,21 @@ from schema.game_state import GameState
 from schema.quest import Quest, QuestDescription
 from tools.end_quest_tool import EndQuestTool
 from utils.context_utils import (
+    FinishActionException,
     await_ask,
     get_current_quest,
     get_game_state,
-    save_game_state, FinishActionException,
+    save_game_state,
 )
 from utils.generation_utils import (
     await_streamed_block,
+    generate_likelihood_estimation,
     generate_quest_arc,
-    send_story_generation, generate_likelihood_estimation,
+    send_story_generation,
 )
 from utils.interruptible_python_agent import InterruptiblePythonAgent
 from utils.moderation_utils import mark_block_as_excluded
-from utils.tags import QuestIdTag, QuestTag, TagKindExtensions
+from utils.tags import InstructionsTag, QuestIdTag, QuestTag, TagKindExtensions
 
 
 class QuestAgent(InterruptiblePythonAgent):
@@ -69,6 +71,7 @@ class QuestAgent(InterruptiblePythonAgent):
         if len(game_state.quest_arc) >= len(game_state.quests):
             quest_description = game_state.quest_arc[len(game_state.quests) - 1]
         else:
+            logging.warning("QUEST DESCRIPTION IS NONE.")
             quest_description = None
 
         logging.debug(
@@ -96,10 +99,30 @@ class QuestAgent(InterruptiblePythonAgent):
             )
 
             if quest_description is not None:
-                prompt = f"{game_state.player.name} is about to go on a mission to {quest_description.goal} at {quest_description.location}. Describe the first few things they do in a few sentences"
+                context.chat_history.append_system_message(
+                    text=f"{game_state.player.name} is embarking on a quest to {quest_description.goal} "
+                    f"at {quest_description.location}.",
+                    tags=[
+                        Tag(
+                            kind=TagKindExtensions.INSTRUCTIONS,
+                            name=InstructionsTag.QUEST,
+                        ),
+                        QuestIdTag(quest_id=quest.name),
+                    ],
+                )
+                num_paragraphs = randint(1, 2)  # noqa: S311
+                prompt = (
+                    f"Describe the first few things they do in a {num_paragraphs} short paragraphs. "
+                    f"DO NOT present them with a challenge or obstacle in this description. Just set the scene."
+                    f"{game_state.player.name} MUST NOT achieve their goal in the generated paragraphs."
+                )
             else:
                 # here as a fallback
-                prompt = f"{game_state.player.name} is about to go on a mission. Describe the first few things they do in a few sentences"
+                num_paragraphs = randint(1, 2)  # noqa: S311
+                prompt = (
+                    f"{game_state.player.name} is embarking on a quest. Describe the first few things they do "
+                    f"in a {num_paragraphs} short paragraphs."
+                )
             block = send_story_generation(
                 prompt=prompt,
                 quest_name=quest.name,
@@ -107,7 +130,9 @@ class QuestAgent(InterruptiblePythonAgent):
             )
             await_streamed_block(block, context)
 
-            self.create_problem(game_state, context, quest, quest_description=quest_description)
+            self.create_problem(
+                game_state, context, quest, quest_description=quest_description
+            )
 
             save_game_state(game_state, context)
         else:
@@ -133,7 +158,9 @@ class QuestAgent(InterruptiblePythonAgent):
             try:
                 if self.evaluate_solution(game_state, context, quest):
                     # TODO: tag last user message as solution
-                    self.generate_solution(game_state, context, quest)
+                    self.generate_solution(
+                        game_state, context, quest, quest_description.goal
+                    )
                 else:
                     self.describe_failure(game_state, context, quest)
                     quest.user_problem_solutions.pop()
@@ -176,7 +203,9 @@ class QuestAgent(InterruptiblePythonAgent):
                     )
 
             if len(quest.user_problem_solutions) != quest.num_problems_to_encounter:
-                self.create_problem(game_state, context, quest, quest_description=quest_description)
+                self.create_problem(
+                    game_state, context, quest, quest_description=quest_description
+                )
                 quest.user_problem_solutions.append(
                     await_ask(
                         f"What does {player.name} do next?",
@@ -190,9 +219,15 @@ class QuestAgent(InterruptiblePythonAgent):
             save_game_state(game_state, context)
 
             if quest_description is not None:
-                prompt = f"How does this mission end? {player.name} should achieve their goal of {quest_description.goal}"
+                prompt = (
+                    f"Complete the story of the {player.name}'s current quest. {player.name} should achieve "
+                    f"the goal of '{quest_description.goal}', but NOT their overall goal of {player.motivation}"
+                )
             else:
-                prompt = f"How does this mission end? {player.name} should not yet achieve their overall goal of {game_state.player.motivation}"
+                prompt = (
+                    f"Complete the story of the {player.name}'s current quest. {player.name} should not yet "
+                    f"achieve their overall goal of '{player.motivation}'"
+                )
             story_end_block = send_story_generation(
                 prompt,
                 quest_name=quest.name,
@@ -209,13 +244,34 @@ class QuestAgent(InterruptiblePythonAgent):
         return [Tag(kind=TagKindExtensions.QUEST, name=part), QuestIdTag(quest.name)]
 
     def create_problem(
-        self, game_state: GameState, context: AgentContext, quest: Quest, quest_description: QuestDescription
+        self,
+        game_state: GameState,
+        context: AgentContext,
+        quest: Quest,
+        quest_description: QuestDescription,
     ):
-        if len(quest.user_problem_solutions) == quest.num_problems_to_encounter -1:
+        if len(quest.user_problem_solutions) == quest.num_problems_to_encounter - 1:
             # if last problem, try to make it make sense for wrapping things up
-            prompt = f"Describe the last problem {game_state.player.name} needs to overcome in order to finish the quest: {quest_description.goal}."
+            num_paragraphs = randint(1, 2)  # noqa: S311
+            prompt = (
+                f"Continue the story of {game_state.player.name} quest. Write about them encountering a "
+                f"challenge that prevents them from completing their current quest.\n"
+                f"DO NOT SOLVE the challenge for {game_state.player.name}. "
+                f"The story should allow {game_state.player.name} to decide how to attempt to complete their "
+                f"quest. The story MUST continue the current story arc of the quest. The story should be a "
+                f"total of {num_paragraphs} short paragraphs."
+            )
         else:
-            prompt = f"Oh no! {game_state.player.name} encounters a new problem. Describe the problem."
+            num_paragraphs = randint(1, 2)  # noqa: S311
+            prompt = (
+                f"Write {num_paragraphs} short paragraphs that present {game_state.player.name} with a single "
+                f"challenge on their current quest ({quest_description.location}, {quest_description.goal}). The "
+                f"challenge MUST NOT repeat (or be equivalent to) a prior challenge faced by "
+                f"{game_state.player.name}.\n"
+                f"DO NOT introduce more than one problem. DO NOT SOLVE the challenge for {game_state.player.name}. "
+                f"The story MUST continue the current story arc of the quest. The story SHOULD allow "
+                f"{game_state.player.name} to decide how to attempt to solve the challenge."
+            )
         problem_block = send_story_generation(
             prompt=prompt,
             quest_name=quest.name,
@@ -232,9 +288,12 @@ class QuestAgent(InterruptiblePythonAgent):
                 description=updated_problem_block.text, context=context
             )
 
-    def evaluate_solution(self, game_state: GameState, context: AgentContext, quest: Quest):
+    def evaluate_solution(
+        self, game_state: GameState, context: AgentContext, quest: Quest
+    ):
         prompt = (
-            f"{game_state.player.name} tries to solve the problem by: {quest.user_problem_solutions[-1]}. How likely is this to succeed? "
+            f"{game_state.player.name} tries to solve the problem by: {quest.user_problem_solutions[-1]}. "
+            f"How likely is this to succeed? "
             f"Please consider their abilities and whether any referenced objects are nearby or in their inventory. "
             f"ONLY RESPOND WITH ONE OF [VERY UNLIKELY, UNLIKELY, LIKELY, VERY LIKELY]"
         )
@@ -254,27 +313,28 @@ class QuestAgent(InterruptiblePythonAgent):
             required_roll = 0.1
         else:
             required_roll = 0.5
-        roll = random()
+        roll = random()  # noqa: S311
         succeeded = roll > required_roll
-        dice_roll_message = json.dumps ({
-            "required" : required_roll,
-            "rolled" : roll,
-            "success" : succeeded
-        })
+        dice_roll_message = json.dumps(
+            {"required": required_roll, "rolled": roll, "success": succeeded}
+        )
         context.chat_history.append_system_message(
-            dice_roll_message,
-            tags=self.tags(QuestTag.DICE_ROLL, quest)
+            dice_roll_message, tags=self.tags(QuestTag.DICE_ROLL, quest)
         )
         return succeeded
 
-
-
     def generate_solution(
-        self, game_state: GameState, context: AgentContext, quest: Quest
+        self,
+        game_state: GameState,
+        context: AgentContext,
+        quest: Quest,
+        quest_goal: str,
     ):
+        num_paragraphs = randint(1, 2)  # noqa: S311
         prompt = (
             f"{game_state.player.name} tries to solve the problem by: {quest.user_problem_solutions[-1]}, and it totally works.\n"
-            f"Describe what happens."
+            f"Describe what happens in {num_paragraphs} short paragraphs. As part of the description, DO NOT have "
+            f"{game_state.player.name} completing the quest goal of {quest_goal}"
         )
         solution_block = send_story_generation(
             prompt=prompt,
@@ -286,9 +346,10 @@ class QuestAgent(InterruptiblePythonAgent):
     def describe_failure(
         self, game_state: GameState, context: AgentContext, quest: Quest
     ):
+        num_paragraphs = randint(1, 2)  # noqa: S311
         prompt = (
             f"{game_state.player.name} tries to solve the problem by: {quest.user_problem_solutions[-1]}, and it fails.\n"
-            f"Describe what happens."
+            f"Describe what happens in {num_paragraphs} short paragraphs."
         )
         solution_block = send_story_generation(
             prompt=prompt,

--- a/src/endpoints/npc_endpoints.py
+++ b/src/endpoints/npc_endpoints.py
@@ -1,4 +1,3 @@
-import time
 import uuid
 from datetime import datetime, timezone
 from typing import List
@@ -11,7 +10,7 @@ from steamship.invocable.package_mixin import PackageMixin
 
 from generators.generator_context_utils import get_image_generator
 from schema.game_state import GameState
-from schema.objects import TradeResult, Item
+from schema.objects import Item, TradeResult
 from tools.end_conversation_tool import EndConversationTool
 from tools.start_conversation_tool import StartConversationTool
 
@@ -19,7 +18,6 @@ from tools.start_conversation_tool import StartConversationTool
 from tools.trade_tool import TradeTool
 from utils.context_utils import get_game_state, save_game_state
 from utils.generation_utils import generate_merchant_inventory
-from utils.tags import TagKindExtensions, ItemTag
 
 
 class NpcMixin(PackageMixin):
@@ -81,39 +79,36 @@ class NpcMixin(PackageMixin):
         return result.dict()
 
     @post("/refresh_inventory")
-    def refresh_inventory(
-            self, npc_name: str
-    ) -> List[Item]:
+    def refresh_inventory(self, npc_name: str) -> List[Item]:
         """Starts a conversation with the NPC by the provided name."""
         context = self.agent_service.build_default_context()
         game_state = get_game_state(context)
         return NpcMixin._refresh_inventory(context, game_state, npc_name)
 
-
     @staticmethod
-    def _refresh_inventory(context: AgentContext, game_state: GameState, npc_name: str) -> List[Item]:
-        start = time.perf_counter()
-        generated_items = generate_merchant_inventory(game_state.player, context=context)
+    def _refresh_inventory(
+        context: AgentContext, game_state: GameState, npc_name: str
+    ) -> List[Item]:
+        # start = time.perf_counter()
+        generated_items = generate_merchant_inventory(
+            game_state.player, context=context
+        )
         # refresh game state directly before altering
         game_state = get_game_state(context)
         npc = game_state.find_npc(npc_name)
         npc.inventory = []
         npc.inventory_last_updated = datetime.now(timezone.utc).isoformat()
         for item in generated_items:
-            new_item = Item(
-                name=item[0],
-                description=item[1],
-                id=str(uuid.uuid4())
-            )
+            new_item = Item(name=item[0], description=item[1], id=str(uuid.uuid4()))
             npc.inventory.append(new_item)
         if image_gen := get_image_generator(context):
             tasks = []
             for item in npc.inventory:
-                task = image_gen.request_item_image_generation(item=item, context=context)
+                task = image_gen.request_item_image_generation(
+                    item=item, context=context
+                )
                 tasks.append(task)
                 block = task.wait().blocks[0]
                 item.picture_url = block.raw_data_url
         save_game_state(game_state=game_state, context=context)
         return npc.inventory
-
-

--- a/src/endpoints/quest_endpoints.py
+++ b/src/endpoints/quest_endpoints.py
@@ -1,6 +1,6 @@
 from typing import List, Optional
 
-from steamship import Block, Steamship, SteamshipError, File, Tag
+from steamship import Block, File, Steamship, SteamshipError, Tag
 from steamship.agents.schema import AgentContext
 from steamship.agents.service.agent_service import AgentService
 from steamship.data.tags.tag_constants import RoleTag
@@ -9,10 +9,13 @@ from steamship.invocable.package_mixin import PackageMixin
 
 from tools.end_quest_tool import EndQuestTool
 from tools.start_quest_tool import StartQuestTool
-
-from utils.context_utils import get_audio_narration_generator, get_game_state, save_game_state
+from utils.context_utils import (
+    get_audio_narration_generator,
+    get_game_state,
+    save_game_state,
+)
 from utils.generation_utils import generate_quest_arc
-from utils.tags import QuestIdTag, TagKindExtensions, SceneTag
+from utils.tags import QuestIdTag, SceneTag, TagKindExtensions
 
 
 class QuestMixin(PackageMixin):
@@ -24,7 +27,6 @@ class QuestMixin(PackageMixin):
     def __init__(self, client: Steamship, agent_service: AgentService):
         self.client = client
         self.agent_service = agent_service
-
 
     @post("/generate_quest_arc")
     def generate_quest_arc(self) -> List[dict]:
@@ -107,8 +109,7 @@ class QuestMixin(PackageMixin):
             append_output_to_file=True,
             output_file_id=file.id,
             streaming=True,
-            tags=[Tag(kind=TagKindExtensions.SCENE, name=SceneTag.NARRATION)]
+            tags=[Tag(kind=TagKindExtensions.SCENE, name=SceneTag.NARRATION)],
         )
 
         return generation.wait().blocks[0]
-

--- a/src/generators/music_generators/meta_music_generator.py
+++ b/src/generators/music_generators/meta_music_generator.py
@@ -3,7 +3,6 @@ from typing import Final
 from steamship import Tag, Task
 from steamship.agents.schema import AgentContext
 
-from generators import utils
 from generators.music_generator import MusicGenerator
 from generators.utils import safe_format
 from utils.context_utils import get_game_state, get_server_settings

--- a/src/generators/utils.py
+++ b/src/generators/utils.py
@@ -1,4 +1,3 @@
-
 def safe_format(text: str, params: dict) -> str:
     """Safely formats a user-provided string by replacing {key} with `value` for all (key,value) pairs in `params`."""
     ret = text

--- a/src/schema/objects.py
+++ b/src/schema/objects.py
@@ -1,5 +1,5 @@
 from typing import List, Optional
-from uuid import UUID, uuid4
+from uuid import uuid4
 
 from pydantic import BaseModel, Field
 

--- a/src/schema/server_settings.py
+++ b/src/schema/server_settings.py
@@ -10,7 +10,7 @@ from schema.stable_diffusion_theme import StableDiffusionTheme
 def validate_prompt_args(prompt: str, valid_args: List[str]):
     regex = r"\{(.*?)\}"
     matches = re.finditer(regex, prompt)
-    variable_names = sorted(list(set([match.group(1) for match in matches])))
+    variable_names = sorted({match.group(1) for match in matches})
     for variable_name in variable_names:
         if variable_name not in valid_args:
             return False
@@ -73,12 +73,12 @@ class ServerSettings(BaseModel):
 
     # Language Generation Settings - Function calling
     default_function_capable_llm_model: str = Field("gpt-3.5-turbo", description="")
-    default_function_capable_llm_temperature: float = Field(0.4, description="")
+    default_function_capable_llm_temperature: float = Field(0.0, description="")
     default_function_capable_llm_max_tokens: int = Field(512, description="")
 
     # Language Generation Settings - Story telling
     default_story_model: str = Field("gpt-3.5-turbo", description="")
-    default_story_temperature: float = Field(0.4, description="")
+    default_story_temperature: float = Field(0.7, description="")
     default_story_max_tokens: int = Field(512, description="")
 
     # Narration Generation Settings

--- a/src/schema/stable_diffusion_theme.py
+++ b/src/schema/stable_diffusion_theme.py
@@ -14,8 +14,8 @@ class StableDiffusionTheme(BaseModel):
 
     This allows someone to separate:
      - the prompt (e.g. "a chest of pirate gold") from
-     - the theme (SDXL w/ Lora 1, 2, a particula negative prompt addition, etc
-    ."""
+     - the theme (SDXL w/ Lora 1, 2, a particula negative prompt addition, etc.
+    """
 
     name: str = Field(description="The name of this theme")
 

--- a/src/tools/end_quest_tool.py
+++ b/src/tools/end_quest_tool.py
@@ -22,7 +22,7 @@ from utils.generation_utils import (
     generate_quest_summary,
     send_agent_status_message,
 )
-from utils.tags import AgentStatusMessageTag, CharacterTag, ItemTag, TagKindExtensions
+from utils.tags import AgentStatusMessageTag, CharacterTag, TagKindExtensions
 
 
 class EndQuestTool(Tool):

--- a/src/tools/start_quest_tool.py
+++ b/src/tools/start_quest_tool.py
@@ -1,5 +1,5 @@
 import uuid
-from random import randrange, randint
+from random import randint
 from typing import Any, List, Optional, Union
 
 from steamship import Block, MimeTypes, SteamshipError, Task
@@ -80,9 +80,13 @@ class StartQuestTool(Tool):
         game_state.quests.append(quest)
 
         quest_difficulty_base = 1
-        if game_state.quest_arc is not None and len(game_state.quest_arc) >= len(game_state.quests):
+        if game_state.quest_arc is not None and len(game_state.quest_arc) >= len(
+            game_state.quests
+        ):
             quest_difficulty_base = len(game_state.quests)
-        quest.num_problems_to_encounter =self.num_problems_to_encounter(quest_difficulty_base)
+        quest.num_problems_to_encounter = self.num_problems_to_encounter(
+            quest_difficulty_base
+        )
 
         quest.name = f"{uuid.uuid4()}"
 
@@ -95,9 +99,7 @@ class StartQuestTool(Tool):
         return quest
 
     def num_problems_to_encounter(self, difficulty_base: int) -> int:
-        return (difficulty_base // 4) + 2 + randint(0, 2)
-
-
+        return (difficulty_base // 4) + 2 + randint(0, 2)  # noqa: S311
 
     def run(
         self, tool_input: List[Block], context: AgentContext
@@ -116,7 +118,7 @@ class StartQuestTool(Tool):
             action=FinishAction(
                 input=[
                     Block(
-                        text=f"", # Empty string here to not interfere with prompts in quest_agent
+                        text="",  # Empty string here to not interfere with prompts in quest_agent
                         mime_type=MimeTypes.MKD,
                     )
                 ],

--- a/src/utils/ChatHistoryFilter.py
+++ b/src/utils/ChatHistoryFilter.py
@@ -2,10 +2,20 @@ import logging
 from abc import ABC, abstractmethod
 from typing import List, Optional, Tuple
 
-from steamship import Block, File
+from steamship import Block, File, Tag
+from steamship.agents.schema.message_selectors import tokens
+from steamship.data.tags.tag_constants import RoleTag, TagKind, TagValueKey
+from steamship.data.tags.tag_utils import get_tag, get_tag_value_key
 
+from schema.game_state import GameState
 from utils.moderation_utils import is_block_excluded
-from utils.tags import CharacterTag, QuestIdTag, TagKindExtensions
+from utils.tags import (
+    CharacterTag,
+    InstructionsTag,
+    QuestIdTag,
+    QuestTag,
+    TagKindExtensions,
+)
 
 
 class ChatHistoryFilter(ABC):
@@ -113,7 +123,152 @@ class UnionFilter(ChatHistoryFilter):
             else:
                 last_appended = result[-1]
                 if last_appended[0].index_in_file == included[0].index_in_file:
-                    last_appended[1] = f"{last_appended[1]} && {included[1]}"
+                    result[-1] = (
+                        last_appended[0],
+                        f"{last_appended[1]} && {included[1]}",
+                    )
                 else:
                     result.append(included)
         return result
+
+
+class TrimmingStoryContextFilter(ChatHistoryFilter):
+    def __init__(
+        self,
+        base_filter: ChatHistoryFilter,
+        current_quest_id: str,
+        game_state: GameState,
+        max_tokens: int,
+    ):
+        self._base_filter = base_filter
+        self._current_quest_id = current_quest_id
+        self._game_state = game_state
+        self._max_tokens = max_tokens
+
+    def _calculate_and_store_token_count(self, block: Block) -> int:
+        if not block.text:
+            return 0
+        if value := get_tag_value_key(
+            block.tags, key=TagValueKey.NUMBER_VALUE, kind=TagKind.TOKEN_COUNT
+        ):
+            return value
+        block_tokens = tokens(block)
+        if block.client and block.id:
+            tag = Tag.create(
+                block.client,
+                file_id=block.file_id,
+                block_id=block.id,
+                kind=TagKind.TOKEN_COUNT,
+                value={TagValueKey.NUMBER_VALUE: block_tokens},
+            )
+        else:
+            tag = Tag(
+                kind=TagKind.TOKEN_COUNT,
+                value={TagValueKey.NUMBER_VALUE: block_tokens},
+            )
+        block.tags.append(tag)
+        return block_tokens
+
+    def filter_blocks(  # noqa: C901
+        self, chat_history_file: File
+    ) -> List[Tuple[Block, Optional[str]]]:
+        block_tuples = self._base_filter.filter_blocks(
+            chat_history_file=chat_history_file
+        )
+
+        # drop the unwanted ones
+        block_tuples = [
+            block_tuple
+            for block_tuple in block_tuples
+            if (not is_block_excluded(block_tuple[0]) and block_tuple[0].text)
+        ]
+
+        id_to_reasons = {t[0].id: t[1] for t in block_tuples}
+        blocks = [t[0] for t in block_tuples]
+
+        total_tokens = 0
+
+        # MUST include onboarding message, as it provides the proper overall context.
+        selected_blocks = []
+        for block in blocks:
+            if get_tag(
+                tags=block.tags,
+                kind=TagKindExtensions.INSTRUCTIONS,
+                name=InstructionsTag.ONBOARDING,
+            ):
+                logging.debug(
+                    f"Selecting block: ({block.index_in_file}) [{block.chat_role}] {block.text}"
+                )
+                selected_blocks.append(block)
+                total_tokens += self._calculate_and_store_token_count(block)
+                logging.debug(f"Total tokens: {total_tokens }")
+                break
+
+        # Also, MUST include quest beginning prompt
+        for block in reversed(blocks):
+            if not get_tag(
+                tags=block.tags,
+                kind=TagKindExtensions.INSTRUCTIONS,
+                name=InstructionsTag.QUEST,
+            ):
+                continue
+            if value := get_tag_value_key(
+                tags=block.tags,
+                kind=TagKindExtensions.QUEST,
+                name=QuestTag.QUEST_ID,
+                key="id",
+            ):
+                if value == self._current_quest_id:
+                    logging.debug(
+                        f"Selecting block: ({block.index_in_file}) [{block.chat_role}] {block.text}"
+                    )
+                    selected_blocks.append(block)
+                    total_tokens += self._calculate_and_store_token_count(block)
+                    logging.debug(f"Total tokens: {total_tokens}")
+                    break
+
+        # Now include any assistant/user messages that provide the context.
+        for block in reversed(blocks):
+            if block.chat_role not in [RoleTag.ASSISTANT, RoleTag.USER]:
+                continue
+            if value := get_tag_value_key(
+                tags=block.tags,
+                kind=TagKindExtensions.QUEST,
+                name=QuestTag.QUEST_ID,
+                key="id",
+            ):
+                if value == self._current_quest_id:
+                    if total_tokens < self._max_tokens:
+                        block_tokens = self._calculate_and_store_token_count(block)
+                        if block_tokens + total_tokens < self._max_tokens:
+                            logging.debug(
+                                f"Selecting block: ({block.index_in_file}) [{block.chat_role}] {block.text}"
+                            )
+                            selected_blocks.append(block)
+                            total_tokens += block_tokens
+                            logging.debug(f"Total tokens: {total_tokens}")
+
+        if total_tokens < self._max_tokens:
+            for block in reversed(blocks):
+                if not get_tag(
+                    tags=block.tags,
+                    kind=TagKindExtensions.QUEST,
+                    name=QuestTag.QUEST_SUMMARY,
+                ):
+                    continue
+                if total_tokens < self._max_tokens:
+                    block_tokens = self._calculate_and_store_token_count(block)
+                    if block_tokens + total_tokens < self._max_tokens:
+                        logging.debug(
+                            f"Selecting block: ({block.index_in_file}) [{block.chat_role}] {block.text}"
+                        )
+                        selected_blocks.append(block)
+                        total_tokens += block_tokens
+                        logging.debug(f"Total tokens: {total_tokens}")
+
+        logging.debug(f"TOTAL_TOKENS = {total_tokens}, MAX_TOKENS = {self._max_tokens}")
+        block_list = sorted(selected_blocks, key=lambda b: b.index_in_file)
+        return_tuples = []
+        for block in block_list:
+            return_tuples.append((block, id_to_reasons.get(block.id)))
+        return return_tuples

--- a/src/utils/agent_service.py
+++ b/src/utils/agent_service.py
@@ -8,8 +8,6 @@ from steamship.agents.logging import AgentLogging, StreamingOpts
 from steamship.agents.schema import Action, Agent, FinishAction
 from steamship.agents.schema.context import AgentContext, EmitFunc, Metadata
 from steamship.agents.utils import with_llm
-
-# from steamship.base.client import API_TIMINGS
 from steamship.data import TagKind
 from steamship.data.tags.tag_constants import ChatTag
 from steamship.invocable import PackageService, post
@@ -23,8 +21,6 @@ from utils.context_utils import (
     with_game_state,
     with_server_settings,
 )
-
-# from utils.timing_utils import pretty_print_timings
 from utils.tags import QuestIdTag
 
 

--- a/src/utils/context_utils.py
+++ b/src/utils/context_utils.py
@@ -335,7 +335,7 @@ def switch_history_to_current_quest(
 
     if quest:
         logging.info(
-            f"Switching to Quest Chat History: {quest.name}.",
+            f"Switching to Quest Chat History: {quest.name}",
             extra={
                 AgentLogging.IS_MESSAGE: True,
                 AgentLogging.MESSAGE_TYPE: AgentLogging.THOUGHT,
@@ -436,7 +436,7 @@ def await_ask(
     key = _key_for_question(output) + key_suffix
 
     logging.info(
-        f"Seeking input with await_ask key: {key}.",
+        f"Seeking input with await_ask key: {key}",
         extra={
             AgentLogging.IS_MESSAGE: True,
             AgentLogging.MESSAGE_TYPE: AgentLogging.THOUGHT,
@@ -446,7 +446,7 @@ def await_ask(
 
     if game_state.await_ask_key == key:
         logging.info(
-            f"Last await_ask key matches: {game_state.await_ask_key}.",
+            f"Last await_ask key matches: {game_state.await_ask_key}",
             extra={
                 AgentLogging.IS_MESSAGE: True,
                 AgentLogging.MESSAGE_TYPE: AgentLogging.THOUGHT,
@@ -461,7 +461,7 @@ def await_ask(
                 save_game_state(game_state, context)
                 answer = context.chat_history.last_user_message.text
                 logging.info(
-                    f"Using last user input as answer: {answer}.",
+                    f"Using last user input as answer: {answer}",
                     extra={
                         AgentLogging.IS_MESSAGE: True,
                         AgentLogging.MESSAGE_TYPE: AgentLogging.THOUGHT,
@@ -474,7 +474,7 @@ def await_ask(
     game_state.await_ask_key = key
 
     logging.info(
-        f"Awaiting user response with await_ask key: {game_state.await_ask_key}.",
+        f"Awaiting user response with await_ask key: {game_state.await_ask_key}",
         extra={
             AgentLogging.IS_MESSAGE: True,
             AgentLogging.MESSAGE_TYPE: AgentLogging.THOUGHT,

--- a/src/utils/generation_utils.py
+++ b/src/utils/generation_utils.py
@@ -15,6 +15,7 @@ from typing import List, Optional, Tuple
 
 from steamship import Block, Tag
 from steamship.agents.schema import AgentContext
+from steamship.agents.schema.message_selectors import tokens
 from steamship.data import TagKind
 from steamship.data.block import StreamState
 from steamship.data.tags.tag_constants import ChatTag, RoleTag, TagValueKey
@@ -26,11 +27,13 @@ from utils.ChatHistoryFilter import (
     LastInventoryFilter,
     QuestNameFilter,
     TagFilter,
+    TrimmingStoryContextFilter,
     UnionFilter,
 )
 from utils.context_utils import (
     emit,
-    get_audio_narration_generator,
+    get_game_state,
+    get_server_settings,
     get_story_text_generator,
 )
 from utils.tags import (
@@ -63,7 +66,7 @@ def send_story_generation(
     prompt: str, quest_name: str, context: AgentContext
 ) -> Optional[Block]:
     """Generates and sends a background image to the player."""
-    block = do_generation(
+    block = do_token_trimmed_generation(
         context,
         prompt,
         prompt_tags=[
@@ -92,19 +95,20 @@ def send_story_generation(
             ]
         ),
         generation_for="Quest Content",
-        stop_tokens=["\n"],
+        # stop_tokens=["\n"],
     )
     return block
+
 
 def generate_likelihood_estimation(
     prompt: str, quest_name: str, context: AgentContext
 ) -> Optional[Block]:
-    """Generates and sends a background image to the player."""
-    block = do_generation(
+    """Generates a likelihood calculation of success for an event."""
+    block = do_token_trimmed_generation(
         context,
         prompt,
         prompt_tags=[
-            Tag(kind=TagKindExtensions.QUEST, name=QuestTag.QUEST_PROMPT),
+            Tag(kind=TagKindExtensions.QUEST, name=QuestTag.LIKELIHOOD_EVALUATION),
             QuestIdTag(quest_name),
         ],
         output_tags=[],
@@ -132,10 +136,11 @@ def generate_likelihood_estimation(
     )
     return block
 
+
 def generate_quest_summary(quest_name: str, context: AgentContext) -> Optional[Block]:
     """Generates and sends a quest summary to the player."""
     prompt = "Please summarize the above quest in one to two sentences."
-    block = do_generation(
+    block = do_token_trimmed_generation(
         context,
         prompt,
         prompt_tags=[
@@ -148,7 +153,7 @@ def generate_quest_summary(quest_name: str, context: AgentContext) -> Optional[B
         ],
         filter=QuestNameFilter(quest_name=quest_name),
         generation_for="Quest Summary",
-        stop_tokens=["\n"],
+        # stop_tokens=["\n"],
     )
     return block
 
@@ -157,7 +162,7 @@ def generate_quest_item(
     quest_name: str, player: HumanCharacter, context: AgentContext
 ) -> (str, str):
     """Generates a found item from a quest, returning a tuple of its name and description"""
-    prompt = f"What object or item did {player.name} find during that story? It should fit the setting of the story and help {player.name} achieve their goal. Please respond only with ITEM NAME: <name> ITEM DESCRIPTION: <description>"
+    prompt = f"What item did {player.name} find during that story? It should fit the setting of the story and help {player.name} achieve their goal. Please respond only with ITEM NAME: <name> ITEM DESCRIPTION: <description>"
     block = do_generation(
         context,
         prompt,
@@ -241,7 +246,23 @@ def generate_merchant_inventory(
 def generate_quest_arc(
     player: HumanCharacter, context: AgentContext
 ) -> List[QuestDescription]:
-    prompt = f"Please list 10 quests of increasing difficulty that {player.name} will go in to achieve their overall goal of {player.motivation}. They should fit the setting of the story. Please respond only with QUEST GOAL: <goal> QUEST LOCATION: <location name>"
+    prompt = (
+        f"Please list 10 quests of increasing difficulty that {player.name} will go in to achieve their overall "
+        f"goal of {player.motivation}. They should fit the setting of the story. Responses should only be in the "
+        f"form of: QUEST GOAL: <goal> QUEST LOCATION: <location name>\n"
+        f"Example (for a quest game for a dog):\n"
+        f"QUEST GOAL: find a treat QUEST LOCATION: Dog Park\n"
+        f"QUEST GOAL: make a friend QUEST LOCATION: Main Street\n"
+        f"QUEST GOAL: get bacon from the butcher QUEST LOCATION: Butcher Shop\n"
+        f"QUEST GOAL: learn a new trick QUEST LOCATION: Trainer's Office\n"
+        f"QUEST GOAL: fetch the newspaper QUEST LOCATION: Owner's House\n"
+        f"QUEST GOAL: prevent a robbery QUEST LOCATION: Owner's Store\n"
+        f"QUEST GOAL: impress the teacher during a show and tell QUEST LOCATION: Owner's Kid's School\n"
+        f"QUEST GOAL: steal some turkey QUEST LOCATION: Thanksgiving Dinner at Grandma's\n"
+        f"QUEST GOAL: get your nails trimmed QUEST LOCATION: Dog Wash\n"
+        f"QUEST GOAL: win an award QUEST LOCATION: Westminister Dog Show\n"
+    )
+
     block = do_generation(
         context,
         prompt,
@@ -272,38 +293,76 @@ def generate_quest_arc(
             parts = item.split("QUEST LOCATION:")
             if len(parts) == 2:
                 goal = parts[0].strip()
-                location = parts[1].strip()
+                location = parts[1].strip().rstrip(".")
                 if "\n" in location:
                     location = location[: location.index("\n")]
                 result.append(QuestDescription(goal=goal, location=location))
     return result
 
 
-def generate_story_intro(
-        player: HumanCharacter,
-        context: AgentContext
-) -> str:
+def generate_story_intro(player: HumanCharacter, context: AgentContext) -> str:
     prompt = f"Please write a few sentences of introduction to the character {player.name} as they embark on their journey to {player.motivation}."
     block = do_generation(
         context,
         prompt,
-        prompt_tags=[Tag(
-            kind=TagKindExtensions.CHARACTER,
-            name=CharacterTag.INTRODUCTION_PROMPT,
-        )],
-        output_tags=[Tag(kind=TagKindExtensions.CHARACTER, name=CharacterTag.INTRODUCTION)],
-        filter = TagFilter([
+        prompt_tags=[
+            Tag(
+                kind=TagKindExtensions.CHARACTER,
+                name=CharacterTag.INTRODUCTION_PROMPT,
+            )
+        ],
+        output_tags=[
+            Tag(kind=TagKindExtensions.CHARACTER, name=CharacterTag.INTRODUCTION)
+        ],
+        filter=TagFilter(
+            [
                 (TagKindExtensions.CHARACTER, CharacterTag.NAME),
                 (TagKindExtensions.CHARACTER, CharacterTag.DESCRIPTION),
                 (TagKindExtensions.CHARACTER, CharacterTag.BACKGROUND),
                 (TagKindExtensions.STORY_CONTEXT, StoryContextTag.GENRE),
                 (TagKindExtensions.STORY_CONTEXT, StoryContextTag.TONE),
-                (TagKindExtensions.CHARACTER, CharacterTag.INTRODUCTION_PROMPT)
-            ]),
+                (TagKindExtensions.CHARACTER, CharacterTag.INTRODUCTION_PROMPT),
+            ]
+        ),
         generation_for="Character Introduction",
         streaming=False,
     )
     return block.text
+
+
+def do_token_trimmed_generation(
+    context: AgentContext,
+    prompt: str,
+    prompt_tags: List[Tag],
+    output_tags: List[Tag],
+    filter: ChatHistoryFilter,
+    generation_for: str,  # For debugging output
+    stop_tokens: Optional[List[str]] = None,
+    new_file: bool = False,
+    streaming: bool = True,
+) -> Block:
+    game_state = get_game_state(context=context)
+    server_settings = get_server_settings(context)
+    avail_tokens = 4096 - server_settings.default_story_max_tokens
+    avail_tokens -= tokens(Block(text=prompt))
+
+    block = do_generation(
+        context,
+        prompt,
+        prompt_tags=prompt_tags,
+        output_tags=output_tags,
+        filter=TrimmingStoryContextFilter(
+            base_filter=filter,
+            current_quest_id=game_state.current_quest,
+            game_state=game_state,
+            max_tokens=avail_tokens,
+        ),
+        generation_for=generation_for,
+        stop_tokens=stop_tokens,
+        new_file=new_file,
+        streaming=streaming,
+    )
+    return block
 
 
 def do_generation(
@@ -334,7 +393,7 @@ def do_generation(
         ]
     )
 
-    context.chat_history.append_system_message(
+    prompt_block = context.chat_history.append_system_message(
         text=prompt,
         tags=prompt_tags,
     )
@@ -343,15 +402,21 @@ def do_generation(
         chat_history_file=context.chat_history.file, filter_for=generation_for
     )
 
+    if prompt_block.index_in_file not in block_indices:
+        block_indices.append(prompt_block.index_in_file)
+
     options = {}
     if stop_tokens:
         options["stop"] = stop_tokens
 
     output_file_id = None if new_file else context.chat_history.file.id
 
+    # don't pollute workspace with temporary/working files that contain data like: "LIKELY"
+    append_output_to_file = False if not output_file_id else True
+
     task = generator.generate(
         tags=output_tags,
-        append_output_to_file=True,
+        append_output_to_file=append_output_to_file,
         input_file_id=context.chat_history.file.id,
         output_file_id=output_file_id,
         streaming=streaming,
@@ -361,8 +426,10 @@ def do_generation(
     task.wait()
     blocks = task.output.blocks
     block = blocks[0]
-    block = Block.get(block.client, _id=block.id)
-    emit(output=block, context=context)
+    # only re-fetch block if it is not ephemeral...
+    if block.client and block.id:
+        block = Block.get(block.client, _id=block.id)
+    emit(output=block, context=context)  # todo: should emit be optional ?
     return block
 
 

--- a/src/utils/tags.py
+++ b/src/utils/tags.py
@@ -25,6 +25,8 @@ class TagKindExtensions(str, Enum):
 
     QUEST_ARC = "quest_arc"
 
+    # This tag is used to identify a set of instructions for a portion of the story
+    INSTRUCTIONS = "instructions"
 
 
 class AgentStatusMessageTag(str, Enum):
@@ -68,6 +70,7 @@ class CharacterTag(str, Enum):
     INTRODUCTION = "introduction"
     INTRODUCTION_PROMPT = "introduction_prompt"
 
+
 class StoryContextTag(str, Enum):
 
     GENRE = "genre"
@@ -84,6 +87,7 @@ class QuestTag(str, Enum):
     QUEST_SUMMARY = "quest_summary"
     ITEM_GENERATION_CONTENT = "item_generation_content"
     ITEM_GENERATION_PROMPT = "item_generation_prompt"
+    LIKELIHOOD_EVALUATION = "likelihood_evaluation"
     DICE_ROLL = "dice_roll"
 
 
@@ -120,3 +124,8 @@ class QuestIdTag(Tag):
 class QuestArcTag(str, Enum):
     PROMPT = "prompt"
     RESULT = "result"
+
+
+class InstructionsTag(str, Enum):
+    ONBOARDING = "onboarding"
+    QUEST = "quest"

--- a/src/utils/timing_utils.py
+++ b/src/utils/timing_utils.py
@@ -1,6 +1,7 @@
 from typing import List, Tuple
 
-class RouteTiming():
+
+class RouteTiming:
     url: str
     call_count: int = 0
     total_time: float = 0
@@ -8,17 +9,14 @@ class RouteTiming():
     def __init__(self, url: str):
         self.url = url
 
-
     def avg_time(self) -> float:
         return self.total_time / self.call_count
 
     def nice_url(self) -> str:
         if "/v1/" in self.url:
-            return self.url[self.url.index("/v1/")+4:]
+            return self.url[self.url.index("/v1/") + 4 :]
         else:
             return self.url
-
-
 
 
 def pretty_print_timings(timings: List[Tuple[str, float]]):
@@ -36,6 +34,8 @@ def pretty_print_timings(timings: List[Tuple[str, float]]):
     route_timings_list.sort(key=lambda t: t.total_time, reverse=True)
 
     total_time = sum([route_timing.total_time for route_timing in route_timings_list])
-    print('| Route          | Total Time | Num Calls | Avg Per | % of total |')
+    print("| Route          | Total Time | Num Calls | Avg Per | % of total |")
     for route_timing in route_timings_list:
-        print(f'| {route_timing.nice_url():30} | {route_timing.total_time:.3f} | {route_timing.call_count:3} | {route_timing.avg_time():.3f} | {route_timing.total_time / total_time * 100: .1f} |' )
+        print(
+            f"| {route_timing.nice_url():30} | {route_timing.total_time:.3f} | {route_timing.call_count:3} | {route_timing.avg_time():.3f} | {route_timing.total_time / total_time * 100: .1f} |"
+        )

--- a/steamship.json
+++ b/steamship.json
@@ -1,6 +1,6 @@
 {
 	"type": "package",
-	"handle": "ai-adventure-ted",
+	"handle": "ai-adventure-doug",
 	"version": "1.0.4-rc.17",
 	"description": "",
 	"author": "",

--- a/tests/steamship_tests/endpoints/test_npc_endpoints.py
+++ b/tests/steamship_tests/endpoints/test_npc_endpoints.py
@@ -22,15 +22,15 @@ def get_merchant(gs: GameState) -> Optional[Merchant]:
 def test_trade_endpoint_buy(
     invocable_handler: Callable[[str, str, Optional[dict]], dict]
 ):
-    GOLD = 1000
+    gold = 1000
 
     # Bring us to 1000 gold
-    invocable_handler("POST", "game_state", {"player": {"gold": GOLD}})
+    invocable_handler("POST", "game_state", {"player": {"gold": gold}})
 
     # Get the merchant
     gs = GameState.parse_obj(invocable_handler("GET", "game_state", {}).get("data"))
 
-    assert gs.player.gold == GOLD
+    assert gs.player.gold == gold
 
     merchant = get_merchant(gs)
     assert merchant
@@ -45,7 +45,7 @@ def test_trade_endpoint_buy(
     result = TradeResult.parse_obj(result.get("data"))
 
     assert result.player_gold_delta == -1 * merchant.inventory[0].price()
-    assert result.player_gold == GOLD - merchant.inventory[0].price()
+    assert result.player_gold == gold - merchant.inventory[0].price()
     assert result.player_bought
     assert result.player_bought[0] == merchant.inventory[0]
 
@@ -53,8 +53,8 @@ def test_trade_endpoint_buy(
 def test_trade_tool_buy():
     with Steamship.temporary_workspace() as client:
         context, game_state = prepare_state(client)
-        GOLD = 1000
-        game_state.player.gold = GOLD
+        gold = 1000
+        game_state.player.gold = gold
 
         merchant = get_merchant(game_state)
         assert merchant
@@ -63,23 +63,26 @@ def test_trade_tool_buy():
         to_buy_item = merchant.inventory[0]
         to_buy = [to_buy_item.name]
 
-        result = TradeTool(counter_party=merchant).attempt_trade(game_state, context, [], to_buy)
+        result = TradeTool(counter_party=merchant).attempt_trade(
+            game_state, context, [], to_buy
+        )
 
         assert result.player_gold_delta == -1 * to_buy_item.price()
-        assert result.player_gold == GOLD - to_buy_item.price()
+        assert result.player_gold == gold - to_buy_item.price()
         assert result.player_bought
         assert result.player_bought[0] == to_buy_item
 
         assert game_state.player.inventory[0] == to_buy_item
 
+
 @pytest.mark.parametrize("invocable_handler", [AdventureGameService], indirect=True)
 def test_trade_endpoint_sell(
     invocable_handler: Callable[[str, str, Optional[dict]], dict]
 ):
-    GOLD = 1000
+    gold = 1000
 
     # Bring us to 1000 gold
-    invocable_handler("POST", "game_state", {"player": {"gold": GOLD}})
+    invocable_handler("POST", "game_state", {"player": {"gold": gold}})
     invocable_handler(
         "POST", "game_state", {"player": {"inventory": [{"name": "A Bandana"}]}}
     )
@@ -87,7 +90,7 @@ def test_trade_endpoint_sell(
     # Get the merchant
     gs = GameState.parse_obj(invocable_handler("GET", "game_state", {}).get("data"))
 
-    assert gs.player.gold == GOLD
+    assert gs.player.gold == gold
     assert len(gs.player.inventory) == 1
 
     bandana: Item = gs.player.inventory[0]
@@ -108,7 +111,7 @@ def test_trade_endpoint_sell(
     result = TradeResult.parse_obj(result.get("data"))
 
     assert result.player_gold_delta == bandana.price()
-    assert result.player_gold == GOLD + bandana.price()
+    assert result.player_gold == gold + bandana.price()
     assert len(result.player_bought) == 0
     assert len(result.player_sold) == 1
     assert result.player_sold[0] == bandana

--- a/tests/steamship_tests/endpoints/test_quest_endpoints.py
+++ b/tests/steamship_tests/endpoints/test_quest_endpoints.py
@@ -73,11 +73,11 @@ def test_calling_start_quest_causes_active_quest(
 def test_going_on_quest_consumes_energy(
     invocable_handler: Callable[[str, str, Optional[dict]], dict]
 ):
-    ENERGY = 1000
+    energy = 1000
 
-    invocable_handler("POST", "game_state", {"player": {"energy": ENERGY}})
+    invocable_handler("POST", "game_state", {"player": {"energy": energy}})
     gs = GameState.parse_obj(invocable_handler("GET", "game_state", {}).get("data"))
-    assert gs.player.energy == ENERGY
+    assert gs.player.energy == energy
 
     result = invocable_handler("POST", "start_quest", {})
     quest: Quest = Quest.parse_obj(result.get("data"))
@@ -107,10 +107,10 @@ def test_going_on_quest_impossible_if_insufficient_energy(
     assert server_settings.quest_cost > 0
 
     # Not enough energy!
-    ENERGY = server_settings.quest_cost - 1
-    invocable_handler("POST", "game_state", {"player": {"energy": ENERGY}})
+    energy = server_settings.quest_cost - 1
+    invocable_handler("POST", "game_state", {"player": {"energy": energy}})
     gs = GameState.parse_obj(invocable_handler("GET", "game_state", {}).get("data"))
-    assert gs.player.energy == ENERGY
+    assert gs.player.energy == energy
 
     # Now try to start a quest
     result = invocable_handler("POST", "start_quest", {})


### PR DESCRIPTION
This PR attempts to restructure prompting a bit to allow for more concise prompting that respects known token-size limits of the LLM. As part of this work, various prompt issues are addressed through attempts at various rephrasings and examples.

This PR also turns up the temperature of the story generator, in an attempt to produce more variety in story outcomes, etc. A random number of paragraphs is introduced in an attempt to vary the story pace a tiny bit (unclear if this is ultimately desirable).

The TalkToSomeoneTool is removed from consideration for now.

Small "optimizations" are made (ex: fewer system message update calls, no new files for likelihood blocks, etc.).