### PR TITLE
Add persistent failure mode

### DIFF
--- a/src/schema/game_state.py
+++ b/src/schema/game_state.py
@@ -15,6 +15,7 @@ class ActiveMode(str, Enum):
     QUEST = "quest"
     NPC_CONVERSATION = "npc-conversation"
     DIAGNOSTIC = "diagnostic"
+    ERROR = "error"  # Indicates that the game has hit an unrecoverable error.
 
 
 class GameState(BaseModel):
@@ -65,6 +66,11 @@ class GameState(BaseModel):
     in_conversation_with: Optional[str] = Field(
         None,
         description="The name of the NPC that the user is currently in conversation with.",
+    )
+
+    unrecoverable_error: Optional[str] = Field(
+        None,
+        description="If not null, the description of an unrecoverable error causing a halted game.",
     )
 
     await_ask_key: Optional[str] = Field(
@@ -130,6 +136,8 @@ class GameState(BaseModel):
 
     @property
     def active_mode(self) -> ActiveMode:
+        if self.unrecoverable_error is not None:
+            return ActiveMode.ERROR
         if self.diagnostic_mode is not None:
             return ActiveMode.DIAGNOSTIC  # Diagnostic mode takes precedence
         if not self.is_onboarding_complete():

--- a/src/utils/agent_service.py
+++ b/src/utils/agent_service.py
@@ -21,6 +21,7 @@ from utils.context_utils import (
     with_game_state,
     with_server_settings,
 )
+from utils.error_utils import record_and_throw_unrecoverable_error
 from utils.tags import QuestIdTag
 
 
@@ -558,6 +559,8 @@ class AgentService(PackageService):
                     prompt = "Hi."
                     if e.action.input:
                         prompt = e.action.input[0].text
+                except BaseException as e:
+                    record_and_throw_unrecoverable_error(e, context)
 
             # timings = API_TIMINGS
             # pretty_print_timings(timings)

--- a/src/utils/error_utils.py
+++ b/src/utils/error_utils.py
@@ -1,0 +1,34 @@
+import logging
+
+from steamship.agents.logging import AgentLogging
+from steamship.agents.schema import AgentContext
+
+from utils.context_utils import get_game_state, save_game_state
+
+
+def record_and_throw_unrecoverable_error(e: BaseException, context: AgentContext):
+    logging.exception(e)
+    logging.error(
+        f"Got unexpected exception. {e}",
+        extra={
+            AgentLogging.IS_MESSAGE: True,
+            AgentLogging.MESSAGE_TYPE: AgentLogging.THOUGHT,
+            AgentLogging.MESSAGE_AUTHOR: AgentLogging.AGENT,
+        },
+    )
+
+    # Attempt to transition the game state to ERROR
+    try:
+        gs = get_game_state(context)
+        gs.unrecoverable_error = f"Got unexpected exception. {e}"
+        save_game_state(gs, context)
+    except BaseException as e2:
+        logging.error(
+            f"Unable to persist game state of ERROR. {e2}",
+            extra={
+                AgentLogging.IS_MESSAGE: True,
+                AgentLogging.MESSAGE_TYPE: AgentLogging.THOUGHT,
+                AgentLogging.MESSAGE_AUTHOR: AgentLogging.AGENT,
+            },
+        )
+    raise e

--- a/steamship.json
+++ b/steamship.json
@@ -1,6 +1,6 @@
 {
 	"type": "package",
-	"handle": "ai-adventure-staging",
+	"handle": "ai-adventure",
 	"version": "1.0.4-rc.19",
 	"description": "",
 	"author": "",

--- a/tests/steamship_tests/endpoints/test_error_state.py
+++ b/tests/steamship_tests/endpoints/test_error_state.py
@@ -1,0 +1,45 @@
+from typing import Callable, Optional, Tuple
+
+import pytest
+from steamship import Steamship
+from steamship.agents.schema import AgentContext
+
+from api import AdventureGameService
+from schema.game_state import GameState
+from utils.context_utils import save_game_state
+
+
+@pytest.mark.parametrize(
+    "invocable_handler_with_client", [AdventureGameService], indirect=True
+)
+def test_induce_error(
+    invocable_handler_with_client: Tuple[
+        Callable[[str, str, Optional[dict]], dict], Steamship
+    ]
+):
+    invocable_handler, client = invocable_handler_with_client
+    context = AgentContext.get_or_create(client, context_keys={"_id": "doo"})
+
+    # Now attempt to onboard!
+    gs: GameState = GameState.parse_obj(
+        invocable_handler("GET", "game_state", {}).get("data")
+    )
+    gs.player.description = "A tomato"
+    gs.player.background = "From the farm"
+    gs.player.name = "Tomatokins"
+    gs.diagnostic_mode = (
+        "setting this will cause the complete onboarding step to throw an exception"
+    )
+
+    save_game_state(gs, context)
+
+    # Now we attempt to complete onboarding
+    invocable_handler("POST", "complete_onboarding", {})
+
+    # Now we get the game state and see that it's an error!
+
+    gs2: GameState = GameState.parse_obj(
+        invocable_handler("GET", "game_state", {}).get("data")
+    )
+    assert gs2.unrecoverable_error is not None
+    assert gs2.active_mode == "error"

--- a/tests/steamship_tests/fixtures.py
+++ b/tests/steamship_tests/fixtures.py
@@ -122,6 +122,9 @@ def invocable_handler_with_client(
     # NOTE: get_steamship_client takes either `workspace_handle` or `workspace_id`, but NOT `workspace` as a keyword arg
     new_client = get_steamship_client(workspace_handle=workspace_handle)
 
+    assert workspace.id == new_client.config.workspace_id
+    assert workspace.handle == new_client.config.workspace_handle
+
     def handle(
         verb: str, invocation_path: str, arguments: Optional[dict] = None
     ) -> dict:


### PR DESCRIPTION
@maxwfreu and I both suspect that several of the errors we're seeing on the web side of things fundamentally boil down to:

1. An catastrophic error on the Agent, that
2. Isn't being reported to the web, such that
3. The web keeps trying over and over to continue on, not realizing a dead-end has been reached.

This PR adds a `record_and_throw_unrecoverable_error` that is added to a `try/catch` block on several endpoints if an exception during that invocation represents a catastrophic failure to gameplay.

The `game_state` that is retrieved then has:
- active_mode = `error`
- a description of what the error was.

This way the web side of things can catch that the agent has transitioned to `error` state and display a full-screen explanation to the player that gameplay is no longer available, along with an agent-side error message to report to us.