### PR TITLE
Make camp agent not generate

### DIFF
--- a/src/agents/camp_agent.py
+++ b/src/agents/camp_agent.py
@@ -23,7 +23,7 @@ class CampAgent(Agent):
             if last_message_block.text is not None:
                 last_message = last_message_block.text
 
-        if last_message.lower() == "quest":
+        if "quest" in last_message.lower():
             return Action(tool=self.tools[0].name, output=[], input=[])
         else:
             return FinishAction(

--- a/src/agents/camp_agent.py
+++ b/src/agents/camp_agent.py
@@ -1,21 +1,7 @@
-from typing import List
-
 from steamship import Block
 from steamship.agents.schema import Action, Agent, AgentContext, FinishAction
-from steamship.agents.schema.message_selectors import MessageWindowMessageSelector
 
 from tools.start_quest_tool import StartQuestTool
-from utils.moderation_utils import is_block_excluded
-
-
-class NonExcludedMessageWindowSelector(MessageWindowMessageSelector):
-    def get_messages(self, messages: List[Block]) -> List[Block]:
-        # choice here: if the user has been submitting a bunch of problematic conversation
-        #              then we are ok "forgetting" the distant context. so, we can trim from
-        #              the discovered window, rather than first filtering and then selecting
-        #              via the window.
-        context_messages = super().get_messages(messages)
-        return [msg for msg in context_messages if not is_block_excluded(msg)]
 
 
 class CampAgent(Agent):

--- a/src/agents/camp_agent.py
+++ b/src/agents/camp_agent.py
@@ -6,7 +6,7 @@ from tools.start_quest_tool import StartQuestTool
 
 class CampAgent(Agent):
     """The Camp Agent is currently just
-    the
+    the default agent for CLI debugging.  It is not used in the web game.
     """
 
     def __init__(self, **kwargs):

--- a/src/agents/camp_agent.py
+++ b/src/agents/camp_agent.py
@@ -1,13 +1,10 @@
 from typing import List
 
 from steamship import Block
-from steamship.agents.functional import FunctionsBasedAgent
-from steamship.agents.schema import AgentContext
+from steamship.agents.schema import Action, Agent, AgentContext, FinishAction
 from steamship.agents.schema.message_selectors import MessageWindowMessageSelector
 
-from schema.game_state import GameState
 from tools.start_quest_tool import StartQuestTool
-from utils.context_utils import get_game_state
 from utils.moderation_utils import is_block_excluded
 
 
@@ -21,61 +18,28 @@ class NonExcludedMessageWindowSelector(MessageWindowMessageSelector):
         return [msg for msg in context_messages if not is_block_excluded(msg)]
 
 
-class CampAgent(FunctionsBasedAgent):
-    """The Camp Agent is in charge of your experience while at camp.
-
-    A player is at camp while they are not on a quest.
-
-    CONSIDER: This feels like a FunctionCallingAgent
+class CampAgent(Agent):
+    """The Camp Agent is currently just
+    the
     """
-
-    PROMPT = ""
 
     def __init__(self, **kwargs):
         super().__init__(
             tools=[StartQuestTool()],  # , StartConversationTool()],
-            message_selector=NonExcludedMessageWindowSelector(k=10),
             **kwargs,
         )
 
-    def next_action(self, context: AgentContext):
-        """Choose the next action.
+    def next_action(self, context: AgentContext) -> Action:
+        """Only one action possible - start quest (for CLI usage).  Else return dummy string."""
 
-        We defer to the superclass but have to dynamically set our prompt with the context."""
-        game_state = get_game_state(context)
-        self.set_prompt(game_state)
-        return super().next_action(context)
+        last_message = ""
+        if last_message_block := context.chat_history.last_user_message:
+            if last_message_block.text is not None:
+                last_message = last_message_block.text
 
-    def set_prompt(self, game_state: GameState):
-        npcs = []
-        if game_state and game_state.camp and game_state.camp.npcs:
-            npcs = game_state.camp.npcs
-
-        if npcs:
-            camp_crew = "Your camp has the following people:\n\n" + "\n".join(
-                [f"- {npc.name}" for npc in npcs or []]
-            )
+        if last_message.lower() == "quest":
+            return Action(tool=self.tools[0].name, output=[], input=[])
         else:
-            camp_crew = "Nobody is currently with you at camp."
-
-        self.PROMPT = f"""You are a game engine which helps users make a choice of option.
-
-They only have two options to choose between:
-
-1) Go on a quest
-2) Talk to someone in the camp
-
-{camp_crew}
-
-If they're not asking to go on a quest or talk to someone in a camp, greet them by name, {game_state.player.name}, and concisely entertain casual chit-chat but remind them of what options are at their disposal.
-
-Don't speak like an assistant (how can I assist you?). Instead, speak like a familiar person.
-
-NOTE: Some functions return images, video, and audio files. These multimedia files will be represented in messages as
-UUIDs for Steamship Blocks. When responding directly to a user, you SHOULD print the Steamship Blocks for the images,
-video, or audio as follows: `Block(UUID for the block)`.
-
-Example response for a request that generated an image:
-Here is the image you requested: Block(288A2CA1-4753-4298-9716-53C1E42B726B).
-
-Only use the functions you have been provided with."""
+            return FinishAction(
+                output=[Block(text=f"Camp agent received text: {last_message}")]
+            )

--- a/src/tools/start_quest_tool.py
+++ b/src/tools/start_quest_tool.py
@@ -1,7 +1,7 @@
 import math
 import uuid
 from random import randint
-from typing import Any, List, Optional, Union
+from typing import Any, List, Union
 
 from steamship import Block, MimeTypes, SteamshipError, Task
 from steamship.agents.schema import AgentContext, FinishAction, Tool
@@ -54,7 +54,6 @@ class StartQuestTool(Tool):
         self,
         game_state: GameState,
         context: AgentContext,
-        purpose: Optional[str] = None,
     ) -> Quest:
         server_settings: ServerSettings = get_server_settings(context)
         player = game_state.player
@@ -111,13 +110,9 @@ class StartQuestTool(Tool):
     def run(
         self, tool_input: List[Block], context: AgentContext
     ) -> Union[List[Block], Task[Any]]:
-        purpose = None
         game_state = get_game_state(context)
 
-        if tool_input:
-            purpose = tool_input[0].text
-
-        self.start_quest(game_state, context, purpose)
+        self.start_quest(game_state, context)
 
         player = game_state.player
 


### PR DESCRIPTION
Instead of full removal, make the camp agent just operate directly on the last message.

Typing 'quest' will move on to starting a quest; anything else will just repeat the message back.