### PR TITLE
add action choice generation help endpoint

### DIFF
--- a/src/api.py
+++ b/src/api.py
@@ -33,6 +33,7 @@ from agents.quest_agent import QuestAgent
 from endpoints.camp_endpoints import CampMixin
 from endpoints.game_editor_endpoints import GameEditorMixin
 from endpoints.game_state_endpoints import GameStateMixin
+from endpoints.help_endpoints import HelpMixin
 from endpoints.npc_endpoints import NpcMixin
 from endpoints.onboarding_endpoints import OnboardingMixin
 from endpoints.quest_endpoints import QuestMixin
@@ -111,6 +112,7 @@ class AdventureGameService(AgentService):
         NpcMixin,  # Provides API Endpoints for NPC Chat Management (used by the associated web app)
         OnboardingMixin,  # Provide API Endpoints for Onboarding
         GameEditorMixin,
+        HelpMixin,  # Provide API Endpoints for hinting, etc.,
     ]
     """USED_MIXIN_CLASSES tells Steamship what additional HTTP endpoints to register on your AgentService."""
 
@@ -202,6 +204,10 @@ class AdventureGameService(AgentService):
 
         self.add_mixin(
             GameEditorMixin(client=self.client, agent_service=cast(AgentService, self))
+        )
+
+        self.add_mixin(
+            HelpMixin(client=self.client, agent_service=cast(AgentService, self))
         )
 
         # Instantiate the core game agents

--- a/src/endpoints/help_endpoints.py
+++ b/src/endpoints/help_endpoints.py
@@ -20,7 +20,7 @@ class HelpMixin(PackageMixin):
 
     @post("/generate_action_choices")
     def generate_action_choices(self, **kwargs) -> str:
-        """Generate (synchronously) a JSON map of multiple choice options for user actions in a quest."""
+        """Generate (synchronously) a JSON List of multiple choice options for user actions in a quest."""
 
         try:
             context = self.agent_service.build_default_context()

--- a/src/endpoints/help_endpoints.py
+++ b/src/endpoints/help_endpoints.py
@@ -1,0 +1,35 @@
+import json
+
+from steamship import Steamship, SteamshipError
+from steamship.agents.service.agent_service import AgentService
+from steamship.invocable import post
+from steamship.invocable.package_mixin import PackageMixin
+
+from utils.generation_utils import generate_action_choices
+
+
+class HelpMixin(PackageMixin):
+    """Provides endpoints for providing help to users."""
+
+    agent_service: AgentService
+    client: Steamship
+
+    def __init__(self, client: Steamship, agent_service: AgentService):
+        self.client = client
+        self.agent_service = agent_service
+
+    @post("/generate_action_choices")
+    def generate_action_choices(self, **kwargs) -> str:
+        """Generate (synchronously) a JSON map of multiple choice options for user actions in a quest."""
+
+        try:
+            context = self.agent_service.build_default_context()
+            choices_json_block = generate_action_choices(context=context)
+
+            # loop through encoding just to be extra sure
+            choices = json.loads(choices_json_block.text)
+            return json.dumps(choices)
+        except BaseException as e:
+            raise SteamshipError(
+                "Could not generate next action choices. Please try again.", error=e
+            )

--- a/src/utils/generation_utils.py
+++ b/src/utils/generation_utils.py
@@ -460,13 +460,12 @@ def generate_action_choices(context: AgentContext) -> Block:
     quest_name = game_state.current_quest
 
     prompt = (
-        f"Generate a multiple choice set of four options for the user to select {game_state.player.name}'s next "
-        f'action. The actions should be relevant to the story and include a single "custom" option that '
-        f"allows the user to provide their own action in the story. "
-        "The generated actions should match the tone and narrative voice of the existing story.\n"
-        "Action choices should be returned as a JSON map that provides a single letter key for each action "
-        "choice, as follows: \n"
-        '{"A": "pet the dog", "B": "launch missiles", "C": "dance the macarana", "D": "custom" }'
+        f"Generate a multiple choice set of three options for the user to select {game_state.player.name}'s next "
+        f"action. The actions should be relevant to the story and the current challenge "
+        f"facing {game_state.player.name}. The generated actions should match the tone and narrative voice of the "
+        f"existing story.\n"
+        f"Action choices should be returned as a simple JSON list (and NOT a JSON object).\n"
+        f'Example: ["pet the dog", "launch missiles", "dance the Macarena"]'
     )
 
     block = do_token_trimmed_generation(

--- a/src/utils/tags.py
+++ b/src/utils/tags.py
@@ -29,7 +29,7 @@ class TagKindExtensions(str, Enum):
     INSTRUCTIONS = "instructions"
 
     # This tag is used to identify the token count for a block
-    TOKEN_COUNT = "token_count"
+    TOKEN_COUNT = "token_count"  # noqa: S105
 
 
 class AgentStatusMessageTag(str, Enum):
@@ -84,6 +84,8 @@ class StoryContextTag(str, Enum):
 class QuestTag(str, Enum):
     QUEST_CONTENT = "quest_content"
     QUEST_PROMPT = "quest_prompt"
+    ACTION_CHOICES_PROMPT = "action_choices_prompt"
+    ACTION_CHOICES = "action_choices"
     USER_SOLUTION = "user_solution"
     QUEST_ID = "quest_id"
     QUEST_SUMMARY = "quest_summary"


### PR DESCRIPTION
This PR provides a way for the frontend to get suggestions for next actions from the agent. This generation is (at the moment) considered outside of `ChatHistory`, as it is viewed as a meta-operation on the history. As a result, the output is ephemeral and the prompt is not tagged as part of a quest.

Results are currently returned as a JSON list.

To use, I expect the UI to take the value of the selected option (the text), and pass that in via the prompt endpoint (as it would for "normal" user input).

Here are some sample generations for the same quest (completed by selecting from these options):
![Screenshot 2023-11-17 at 8 44 10 AM](https://github.com/steamship-core/ai-adventure-agent/assets/21148125/ca197a8b-9d9f-43b6-85f6-f3d26441e36d)
![Screenshot 2023-11-17 at 8 45 21 AM](https://github.com/steamship-core/ai-adventure-agent/assets/21148125/935626ef-a35e-43a1-9bdf-acd511c48c5b)
![Screenshot 2023-11-17 at 8 46 21 AM](https://github.com/steamship-core/ai-adventure-agent/assets/21148125/0d709f96-db3f-4854-9a7b-f78077940c65)
![Screenshot 2023-11-17 at 8 47 09 AM](https://github.com/steamship-core/ai-adventure-agent/assets/21148125/a4bddf5b-181c-4b4e-a186-1ea573fea9ab)
![Screenshot 2023-11-17 at 8 48 06 AM](https://github.com/steamship-core/ai-adventure-agent/assets/21148125/c2c8ce9e-3912-4329-a88e-08bd7631eb93)