### PR TITLE
Add more suggestion endpoints: characters, adventure, & images

### DIFF
--- a/src/endpoints/game_editor_endpoints.py
+++ b/src/endpoints/game_editor_endpoints.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Dict
+from typing import Dict, List
 
 from steamship import Block, Steamship, SteamshipError
 from steamship.agents.service.agent_service import AgentService
@@ -73,7 +73,11 @@ class GameEditorMixin(PackageMixin):
 
     @post("/generate_suggestion")
     def generate_suggestion(
-        self, field_name: str = None, unsaved_server_settings: Dict = None, **kwargs
+        self,
+        field_name: str = None,
+        unsaved_server_settings: Dict = None,
+        field_key_path: List = None,
+        **kwargs,
     ) -> Block:
         context = self.agent_service.build_default_context()
 
@@ -93,7 +97,7 @@ class GameEditorMixin(PackageMixin):
 
         generator = EditorSuggestionGenerator()
         task = generator.generate_editor_suggestion(
-            field_name, unsaved_server_settings or {}, context
+            field_name, unsaved_server_settings or {}, field_key_path, context
         )
 
         if task and task.output and task.output.blocks:

--- a/src/endpoints/game_editor_endpoints.py
+++ b/src/endpoints/game_editor_endpoints.py
@@ -97,7 +97,7 @@ class GameEditorMixin(PackageMixin):
 
         generator = EditorSuggestionGenerator()
         if suggestion := generator.generate_editor_suggestion(
-            field_name, unsaved_server_settings or {}, field_key_path, context
+            field_name, unsaved_server_settings or {}, field_key_path or [], context
         ):
             return suggestion
 

--- a/src/endpoints/game_editor_endpoints.py
+++ b/src/endpoints/game_editor_endpoints.py
@@ -9,12 +9,10 @@ from steamship.invocable.package_mixin import PackageMixin
 from generators.editor_suggestions.editor_suggestion_generator import (
     EditorSuggestionGenerator,
 )
-from generators.image_generators.stable_diffusion_with_loras import (
-    StableDiffusionWithLorasImageGenerator,
-)
+from generators.image_generators import get_image_generator
 from schema.objects import Item
 from schema.server_settings import ServerSettings
-from utils.context_utils import get_server_settings, save_server_settings
+from utils.context_utils import get_server_settings, get_theme, save_server_settings
 
 
 class GameEditorMixin(PackageMixin):
@@ -47,18 +45,26 @@ class GameEditorMixin(PackageMixin):
                 logging.exception(e)
                 raise e
 
-        image_generator = StableDiffusionWithLorasImageGenerator()
+        server_settings = get_server_settings(context)
 
         if field_name == "item_image":
-            task = image_generator.request_item_image_generation(
+            theme = get_theme(server_settings.item_image_theme, context)
+            generator = get_image_generator(theme)
+            task = generator.request_item_image_generation(
                 Item.editor_demo_object(), context
             )
         elif field_name == "camp_image":
-            task = image_generator.request_camp_image_generation(context)
+            theme = get_theme(server_settings.camp_image_theme, context)
+            generator = get_image_generator(theme)
+            task = generator.request_camp_image_generation(context)
         elif field_name == "profile_image":
-            task = image_generator.request_profile_image_generation(context)
+            theme = get_theme(server_settings.profile_image_theme, context)
+            generator = get_image_generator(theme)
+            task = generator.request_profile_image_generation(context)
         elif field_name == "scene_image":
-            task = image_generator.request_scene_image_generation(
+            theme = get_theme(server_settings.quest_background_theme, context)
+            generator = get_image_generator(theme)
+            task = generator.request_scene_image_generation(
                 "A magical enchanted forest.", context
             )
         else:

--- a/src/endpoints/game_editor_endpoints.py
+++ b/src/endpoints/game_editor_endpoints.py
@@ -96,12 +96,10 @@ class GameEditorMixin(PackageMixin):
                 raise e
 
         generator = EditorSuggestionGenerator()
-        task = generator.generate_editor_suggestion(
+        if suggestion := generator.generate_editor_suggestion(
             field_name, unsaved_server_settings or {}, field_key_path, context
-        )
-
-        if task and task.output and task.output.blocks:
-            return task.output.blocks[0]
+        ):
+            return suggestion
 
         raise SteamshipError(
             message=f"Unable to generate for {field_name} - no block on output."

--- a/src/generators/editor_field_suggestion_generator.py
+++ b/src/generators/editor_field_suggestion_generator.py
@@ -12,7 +12,7 @@ class EditorFieldSuggestionGenerator(BaseModel, ABC):
     ) -> Block:
         pass
 
-    def task_to_str_block(self, task: Task) -> str:
+    def task_to_str_block(self, task: Task) -> Block:
         task.wait()
         if task and task.output and task.output.blocks:
             return task.output.blocks[0]

--- a/src/generators/editor_field_suggestion_generator.py
+++ b/src/generators/editor_field_suggestion_generator.py
@@ -1,0 +1,19 @@
+from abc import ABC, abstractmethod
+
+from pydantic.main import BaseModel
+from steamship import Block, PluginInstance, SteamshipError, Task
+from steamship.agents.schema import AgentContext
+
+
+class EditorFieldSuggestionGenerator(BaseModel, ABC):
+    @abstractmethod
+    def suggest(
+        self, variables: dict, generator: PluginInstance, context: AgentContext
+    ) -> Block:
+        pass
+
+    def task_to_str_block(self, task: Task) -> str:
+        task.wait()
+        if task and task.output and task.output.blocks:
+            return task.output.blocks[0]
+        raise SteamshipError(message="Unable to fetch suggestion")

--- a/src/generators/editor_suggestions/adventure_background_suggestion.py
+++ b/src/generators/editor_suggestions/adventure_background_suggestion.py
@@ -1,0 +1,36 @@
+from steamship import Block, PluginInstance
+from steamship.agents.schema import AgentContext
+
+from generators.editor_field_suggestion_generator import EditorFieldSuggestionGenerator
+from generators.utils import safe_format
+
+
+class AdventureBackgroundSuggestionGenerator(EditorFieldSuggestionGenerator):
+    PROMPT = """I need help! Write a few notes for a director about an scene in a short story.
+
+Be colorful, descriptive, but concise! Use Markdown and bullet points. Include the sections: tone, narrative voice, adventure background story, non-protagonist characters, locations, and important items to the story.
+
+## Genre
+
+{narrative_voice}
+
+## Writing Style
+
+{narrative_tone}
+
+-"""
+
+    @staticmethod
+    def get_field() -> str:
+        return "adventure_background"
+
+    def suggest(
+        self, variables: dict, generator: PluginInstance, context: AgentContext
+    ) -> Block:
+        task = generator.generate(
+            text=safe_format(self.PROMPT, variables),
+            streaming=True,
+            append_output_to_file=True,
+            make_output_public=True,
+        )
+        return self.task_to_str_block(task)

--- a/src/generators/editor_suggestions/adventure_description_suggestion.py
+++ b/src/generators/editor_suggestions/adventure_description_suggestion.py
@@ -1,0 +1,32 @@
+from steamship import Block, PluginInstance
+from steamship.agents.schema import AgentContext
+
+from generators.editor_field_suggestion_generator import EditorFieldSuggestionGenerator
+from generators.utils import safe_format
+
+
+class AdventureDescriptionSuggestionGenerator(EditorFieldSuggestionGenerator):
+    PROMPT = """I need help! I need to create the back of a book jacket for an amazing story. It should captivate people so that they want to read it!
+
+It should only be one or two (short) paragraphs.
+
+Title: {name}
+Tagline: {short_description}
+
+Suggested one-sentence description:"""
+
+    @staticmethod
+    def get_field() -> str:
+        return "description"
+
+    def suggest(
+        self, variables: dict, generator: PluginInstance, context: AgentContext
+    ) -> Block:
+
+        task = generator.generate(
+            text=safe_format(self.PROMPT, variables),
+            streaming=True,
+            append_output_to_file=True,
+            make_output_public=True,
+        )
+        return self.task_to_str_block(task)

--- a/src/generators/editor_suggestions/adventure_goal_suggestion.py
+++ b/src/generators/editor_suggestions/adventure_goal_suggestion.py
@@ -1,0 +1,49 @@
+from steamship import Block, PluginInstance
+from steamship.agents.schema import AgentContext
+
+from generators.editor_field_suggestion_generator import EditorFieldSuggestionGenerator
+from generators.utils import safe_format
+
+
+class AdventureGoalSuggestionGenerator(EditorFieldSuggestionGenerator):
+    PROMPT = """I need help! Finish the main character goal for this short story.
+
+Be short! But creative and colorful. It needs to REALLY capture attention!
+
+Examples of riveting goals:
+- destroy the Ring of Elders
+- get into Harvard
+- escape from jail
+- create a company and take it to IPO
+- fall in love with a supermodel
+- pull off the world's greatest bank heist
+
+Here are the story details. Finish with the goal!
+
+## Genre
+
+{narrative_voice}
+
+## Writing Style
+
+{narrative_tone}
+
+{adventure_background}
+
+## Riveting Protagonist Goal:
+-"""
+
+    @staticmethod
+    def get_field() -> str:
+        return "adventure_goal"
+
+    def suggest(
+        self, variables: dict, generator: PluginInstance, context: AgentContext
+    ) -> Block:
+        task = generator.generate(
+            text=safe_format(self.PROMPT, variables),
+            streaming=True,
+            append_output_to_file=True,
+            make_output_public=True,
+        )
+        return self.task_to_str_block(task)

--- a/src/generators/editor_suggestions/adventure_image_suggestion.py
+++ b/src/generators/editor_suggestions/adventure_image_suggestion.py
@@ -15,7 +15,7 @@ class AdventureImageSuggestionGenerator(EditorFieldSuggestionGenerator):
         self, variables: dict, generator: PluginInstance, context: AgentContext
     ) -> Block:
         server_settings = get_server_settings(context)
-        theme = get_theme(server_settings.camp_image_theme)
+        theme = get_theme(server_settings.camp_image_theme, context)
         generator = get_image_generator(theme)
         task = generator.request_adventure_image_generation(context)
         task.wait()

--- a/src/generators/editor_suggestions/adventure_image_suggestion.py
+++ b/src/generators/editor_suggestions/adventure_image_suggestion.py
@@ -28,5 +28,6 @@ class AdventureImageSuggestionGenerator(EditorFieldSuggestionGenerator):
             image_size="landscape_4_3",
             tags=[],
         )
+        task.wait()
 
         return task.output.blocks[0]

--- a/src/generators/editor_suggestions/adventure_image_suggestion.py
+++ b/src/generators/editor_suggestions/adventure_image_suggestion.py
@@ -11,7 +11,7 @@ from utils.context_utils import get_server_settings
 class AdventureImageSuggestionGenerator(EditorFieldSuggestionGenerator):
     @staticmethod
     def get_field() -> str:
-        return "adventure_image"
+        return "image"
 
     def suggest(
         self, variables: dict, generator: PluginInstance, context: AgentContext

--- a/src/generators/editor_suggestions/adventure_image_suggestion.py
+++ b/src/generators/editor_suggestions/adventure_image_suggestion.py
@@ -1,0 +1,32 @@
+from steamship import Block, PluginInstance
+from steamship.agents.schema import AgentContext
+
+from generators.editor_field_suggestion_generator import EditorFieldSuggestionGenerator
+from generators.image_generators.stable_diffusion_with_loras import (
+    StableDiffusionWithLorasImageGenerator,
+)
+from utils.context_utils import get_server_settings
+
+
+class AdventureImageSuggestionGenerator(EditorFieldSuggestionGenerator):
+    @staticmethod
+    def get_field() -> str:
+        return "adventure_image"
+
+    def suggest(
+        self, variables: dict, generator: PluginInstance, context: AgentContext
+    ) -> Block:
+        image_generator = StableDiffusionWithLorasImageGenerator()
+        server_settings = get_server_settings(context)
+
+        task = image_generator.generate(
+            context,
+            theme_name=server_settings.camp_image_theme,
+            prompt="""Cinematic, 8k, best quality, movie advertising image, adventure, {narrative_voice}, award winning, Title: {name}""",
+            negative_prompt=server_settings.camp_image_negative_prompt,
+            template_vars=variables,
+            image_size="landscape_4_3",
+            tags=[],
+        )
+
+        return task.output.blocks[0]

--- a/src/generators/editor_suggestions/adventure_image_suggestion.py
+++ b/src/generators/editor_suggestions/adventure_image_suggestion.py
@@ -2,10 +2,8 @@ from steamship import Block, PluginInstance
 from steamship.agents.schema import AgentContext
 
 from generators.editor_field_suggestion_generator import EditorFieldSuggestionGenerator
-from generators.image_generators.stable_diffusion_with_loras import (
-    StableDiffusionWithLorasImageGenerator,
-)
-from utils.context_utils import get_server_settings
+from generators.image_generators import get_image_generator
+from utils.context_utils import get_server_settings, get_theme
 
 
 class AdventureImageSuggestionGenerator(EditorFieldSuggestionGenerator):
@@ -16,18 +14,9 @@ class AdventureImageSuggestionGenerator(EditorFieldSuggestionGenerator):
     def suggest(
         self, variables: dict, generator: PluginInstance, context: AgentContext
     ) -> Block:
-        image_generator = StableDiffusionWithLorasImageGenerator()
         server_settings = get_server_settings(context)
-
-        task = image_generator.generate(
-            context,
-            theme_name=server_settings.camp_image_theme,
-            prompt="""Cinematic, 8k, best quality, movie advertising image, adventure, {narrative_voice}, award winning, Title: {name}""",
-            negative_prompt=server_settings.camp_image_negative_prompt,
-            template_vars=variables,
-            image_size="landscape_4_3",
-            tags=[],
-        )
+        theme = get_theme(server_settings.camp_image_theme)
+        generator = get_image_generator(theme)
+        task = generator.request_adventure_image_generation(context)
         task.wait()
-
         return task.output.blocks[0]

--- a/src/generators/editor_suggestions/adventure_name_suggestion.py
+++ b/src/generators/editor_suggestions/adventure_name_suggestion.py
@@ -1,0 +1,72 @@
+import random
+
+from steamship import Block, PluginInstance
+from steamship.agents.schema import AgentContext
+
+from generators.editor_field_suggestion_generator import EditorFieldSuggestionGenerator
+from generators.utils import safe_format
+
+
+class AdventureNameSuggestionGenerator(EditorFieldSuggestionGenerator):
+    PROMPT = """I need help! I need to create an amazing movie title for an interesting movie.
+
+I want it to be about five words -- no longer.
+
+The genre is {genre} and it's got a {genre} vibe!
+
+Suggested Title:"""
+
+    @staticmethod
+    def get_field() -> str:
+        return "name"
+
+    def suggest(
+        self, variables: dict, generator: PluginInstance, context: AgentContext
+    ) -> Block:
+        genre = random.choice(
+            [
+                "comedy",
+                "adventure",
+                "fantasy",
+                "sci-fi",
+                "young adult",
+                "coming of age",
+                "who dunnit",
+                "murder mystery",
+                "thriller",
+                "kids adventure",
+                "tragedy",
+                "romantic comedy",
+                "romance",
+                "video games",
+                "dungeon's and dragons",
+            ]
+        )
+
+        vibe = random.choice(
+            [
+                "silly",
+                "serious",
+                "punchy",
+                "pixar-like",
+                "novel-like",
+                "heady",
+                "fast paced",
+                "irreverant",
+                "parody",
+                "gonzo",
+                "touching",
+                "fun",
+                "exciting",
+                "creative",
+                "speculative",
+                "whimsical",
+            ]
+        )
+        task = generator.generate(
+            text=safe_format(self.PROMPT, {"genre": genre, "vibe": vibe}),
+            streaming=True,
+            append_output_to_file=True,
+            make_output_public=True,
+        )
+        return self.task_to_str_block(task)

--- a/src/generators/editor_suggestions/adventure_name_suggestion.py
+++ b/src/generators/editor_suggestions/adventure_name_suggestion.py
@@ -18,7 +18,7 @@ Suggested Title:"""
 
     @staticmethod
     def get_field() -> str:
-        return "name"
+        return "adventure_name"
 
     def suggest(
         self, variables: dict, generator: PluginInstance, context: AgentContext

--- a/src/generators/editor_suggestions/adventure_name_suggestion.py
+++ b/src/generators/editor_suggestions/adventure_name_suggestion.py
@@ -18,7 +18,7 @@ Suggested Title:"""
 
     @staticmethod
     def get_field() -> str:
-        return "adventure_name"
+        return "name"
 
     def suggest(
         self, variables: dict, generator: PluginInstance, context: AgentContext

--- a/src/generators/editor_suggestions/adventure_short_description_suggestion.py
+++ b/src/generators/editor_suggestions/adventure_short_description_suggestion.py
@@ -1,0 +1,29 @@
+from steamship import Block, PluginInstance
+from steamship.agents.schema import AgentContext
+
+from generators.editor_field_suggestion_generator import EditorFieldSuggestionGenerator
+from generators.utils import safe_format
+
+
+class AdventureShortDescriptionSuggestionGenerator(EditorFieldSuggestionGenerator):
+    PROMPT = """I need help! I need to create an amazing one-sentence tagline for a movie. It should captivate people so that they want to see it.
+
+The title is: {name}
+
+Suggested one-sentence description:"""
+
+    @staticmethod
+    def get_field() -> str:
+        return "short_description"
+
+    def suggest(
+        self, variables: dict, generator: PluginInstance, context: AgentContext
+    ) -> Block:
+
+        task = generator.generate(
+            text=safe_format(self.PROMPT, variables),
+            streaming=True,
+            append_output_to_file=True,
+            make_output_public=True,
+        )
+        return self.task_to_str_block(task)

--- a/src/generators/editor_suggestions/character_background_suggestion.py
+++ b/src/generators/editor_suggestions/character_background_suggestion.py
@@ -1,0 +1,52 @@
+from steamship import Block, PluginInstance
+from steamship.agents.schema import AgentContext
+
+from generators.editor_field_suggestion_generator import EditorFieldSuggestionGenerator
+from generators.utils import safe_format
+
+
+class CharacterBackgroundSuggestionGenerator(EditorFieldSuggestionGenerator):
+    PROMPT = """Write notes for a novel character's background in markdown. The the character's goals are already developed.. the background should provide a riveting story of progress toward those goals!
+
+Be concise but colorful. Use a few bullet points per section.
+
+# Story
+
+## Title: {name}
+
+## Genre
+
+{narrative_voice}
+
+# Character
+
+## Name
+
+{this_name}
+
+## Tagline
+
+{this_tagline}
+
+## Goal
+
+{adventure_goal}
+
+{this_description}
+
+## Background"""
+
+    @staticmethod
+    def get_field() -> str:
+        return "characters.background"
+
+    def suggest(
+        self, variables: dict, generator: PluginInstance, context: AgentContext
+    ) -> Block:
+        task = generator.generate(
+            text=safe_format(self.PROMPT, variables),
+            streaming=True,
+            append_output_to_file=True,
+            make_output_public=True,
+        )
+        return self.task_to_str_block(task)

--- a/src/generators/editor_suggestions/character_description_suggestion.py
+++ b/src/generators/editor_suggestions/character_description_suggestion.py
@@ -1,0 +1,50 @@
+from steamship import Block, PluginInstance
+from steamship.agents.schema import AgentContext
+
+from generators.editor_field_suggestion_generator import EditorFieldSuggestionGenerator
+from generators.utils import safe_format
+
+
+class CharacterDescriptionSuggestionGenerator(EditorFieldSuggestionGenerator):
+    PROMPT = """Write notes for a novel character in markdown. Be concise but colorful. Use a few bullet points per section.
+
+Include the sections: Goal, Appearance, Skills, Struggles, Quirks
+
+# Story
+
+## Title: {name}
+
+## Genre
+
+{narrative_voice}
+
+# Character
+
+## Name
+
+{this_name}
+
+## Tagline
+
+{this_tagline}
+
+## Goal
+
+{adventure_goal}
+
+## Appearance"""
+
+    @staticmethod
+    def get_field() -> str:
+        return "characters.description"
+
+    def suggest(
+        self, variables: dict, generator: PluginInstance, context: AgentContext
+    ) -> Block:
+        task = generator.generate(
+            text=safe_format(self.PROMPT, variables),
+            streaming=True,
+            append_output_to_file=True,
+            make_output_public=True,
+        )
+        return self.task_to_str_block(task)

--- a/src/generators/editor_suggestions/character_image_suggestion.py
+++ b/src/generators/editor_suggestions/character_image_suggestion.py
@@ -28,5 +28,6 @@ class CharacterImageSuggestionGenerator(EditorFieldSuggestionGenerator):
             image_size="portrait_4_3",
             tags=[],
         )
+        task.wait()
 
         return task.output.blocks[0]

--- a/src/generators/editor_suggestions/character_image_suggestion.py
+++ b/src/generators/editor_suggestions/character_image_suggestion.py
@@ -2,10 +2,7 @@ from steamship import Block, PluginInstance
 from steamship.agents.schema import AgentContext
 
 from generators.editor_field_suggestion_generator import EditorFieldSuggestionGenerator
-from generators.image_generators.stable_diffusion_with_loras import (
-    StableDiffusionWithLorasImageGenerator,
-)
-from utils.context_utils import get_server_settings
+from generators.generator_context_utils import get_profile_image_generator
 
 
 class CharacterImageSuggestionGenerator(EditorFieldSuggestionGenerator):
@@ -16,18 +13,7 @@ class CharacterImageSuggestionGenerator(EditorFieldSuggestionGenerator):
     def suggest(
         self, variables: dict, generator: PluginInstance, context: AgentContext
     ) -> Block:
-        image_generator = StableDiffusionWithLorasImageGenerator()
-        server_settings = get_server_settings(context)
-
-        task = image_generator.generate(
-            context,
-            theme_name=server_settings.profile_image_theme,
-            prompt=server_settings.profile_image_prompt,
-            negative_prompt=server_settings.profile_image_negative_prompt,
-            template_vars=variables,
-            image_size="portrait_4_3",
-            tags=[],
-        )
+        generator = get_profile_image_generator(context)
+        task = generator.request_profile_image_generation(context)
         task.wait()
-
         return task.output.blocks[0]

--- a/src/generators/editor_suggestions/character_image_suggestion.py
+++ b/src/generators/editor_suggestions/character_image_suggestion.py
@@ -1,0 +1,32 @@
+from steamship import Block, PluginInstance
+from steamship.agents.schema import AgentContext
+
+from generators.editor_field_suggestion_generator import EditorFieldSuggestionGenerator
+from generators.image_generators.stable_diffusion_with_loras import (
+    StableDiffusionWithLorasImageGenerator,
+)
+from utils.context_utils import get_server_settings
+
+
+class CharacterImageSuggestionGenerator(EditorFieldSuggestionGenerator):
+    @staticmethod
+    def get_field() -> str:
+        return "characters.image"
+
+    def suggest(
+        self, variables: dict, generator: PluginInstance, context: AgentContext
+    ) -> Block:
+        image_generator = StableDiffusionWithLorasImageGenerator()
+        server_settings = get_server_settings(context)
+
+        task = image_generator.generate(
+            context,
+            theme_name=server_settings.profile_image_theme,
+            prompt=server_settings.profile_image_prompt,
+            negative_prompt=server_settings.profile_image_negative_prompt,
+            template_vars=variables,
+            image_size="portrait_4_3",
+            tags=[],
+        )
+
+        return task.output.blocks[0]

--- a/src/generators/editor_suggestions/character_name_suggestion.py
+++ b/src/generators/editor_suggestions/character_name_suggestion.py
@@ -1,0 +1,29 @@
+from steamship import Block, PluginInstance
+from steamship.agents.schema import AgentContext
+
+from generators.editor_field_suggestion_generator import EditorFieldSuggestionGenerator
+from generators.utils import safe_format
+
+
+class CharacterNameSuggestionGenerator(EditorFieldSuggestionGenerator):
+    PROMPT = """Suggest the name of Character #{this_index} in a story.
+
+Story Name: {name}
+Story Genre: {narrative_voice}
+Story Goal: {adventure_goal}
+Character ${this_index} name:"""
+
+    @staticmethod
+    def get_field() -> str:
+        return "characters.name"
+
+    def suggest(
+        self, variables: dict, generator: PluginInstance, context: AgentContext
+    ) -> Block:
+        task = generator.generate(
+            text=safe_format(self.PROMPT, variables),
+            streaming=True,
+            append_output_to_file=True,
+            make_output_public=True,
+        )
+        return self.task_to_str_block(task)

--- a/src/generators/editor_suggestions/character_tagline_suggestion.py
+++ b/src/generators/editor_suggestions/character_tagline_suggestion.py
@@ -1,0 +1,36 @@
+from steamship import Block, PluginInstance
+from steamship.agents.schema import AgentContext
+
+from generators.editor_field_suggestion_generator import EditorFieldSuggestionGenerator
+from generators.utils import safe_format
+
+
+class CharacterTaglineSuggestionGenerator(EditorFieldSuggestionGenerator):
+    PROMPT = """Suggest short, 5-10 word tagline of Character #{this_index} in a story.
+
+Examples of good taglines illustrate the character's main motivation or struggle, ike this:
+
+- (Karate Girl) Knows the ropes. But does she know herself?
+- (Lawyer Sue) Sue everyone.
+- (Mr. Meatball) Become the biggest meatball.
+- (Dragonmaster) Ascend to the throne
+
+Story Name: {name}
+Story Genre: {narrative_voice}
+Story Goal: {adventure_goal}
+Character ${this_index} tagline: (${this_name}) """
+
+    @staticmethod
+    def get_field() -> str:
+        return "characters.tagline"
+
+    def suggest(
+        self, variables: dict, generator: PluginInstance, context: AgentContext
+    ) -> Block:
+        task = generator.generate(
+            text=safe_format(self.PROMPT, variables),
+            streaming=True,
+            append_output_to_file=True,
+            make_output_public=True,
+        )
+        return self.task_to_str_block(task)

--- a/src/generators/editor_suggestions/editor_suggestion_generator.py
+++ b/src/generators/editor_suggestions/editor_suggestion_generator.py
@@ -1,3 +1,5 @@
+from typing import List
+
 from steamship import SteamshipError, Task
 from steamship.agents.schema import AgentContext
 
@@ -72,26 +74,127 @@ Here are the story details. Finish with the goal!
 
 ## Riveting Protagonist Goal:
 -""",
+    "characters.name": """Suggest the name of Character #{this_index} in a story.
+
+Story Name: {name}
+Story Genre: {narrative_voice}
+Story Goal: {adventure_goal}
+Character ${this_index} name:""",
+    "characters.tagline": """Suggest short, 5-10 word tagline of Character #{this_index} in a story.
+
+Examples of good taglines illustrate the character's main motivation or struggle, ike this:
+
+- (Karate Girl) Knows the ropes. But does she know herself?
+- (Lawyer Sue) Sue everyone.
+- (Mr. Meatball) Become the biggest meatball.
+- (Dragonmaster) Ascend to the throne
+
+Story Name: {name}
+Story Genre: {narrative_voice}
+Story Goal: {adventure_goal}
+Character ${this_index} tagline: (${this_name}) """,
+    "characters.description": """Write notes for a novel character in markdown. Be concise but colorful. Use a few bullet points per section.
+
+Include the sections: Goal, Appearance, Skills, Struggles, Quirks
+
+# Story
+
+## Title: {name}
+
+## Genre
+
+{narrative_voice}
+
+# Character
+
+## Name
+
+{this_name}
+
+## Tagline
+
+{this_tagline}
+
+## Goal
+
+{adventure_goal}
+
+## Appearance""",
+    "characters.background": """Write notes for a novel character's background in markdown. The the character's goals are already developed.. the background should provide a riveting story of progress toward those goals!
+
+Be concise but colorful. Use a few bullet points per section.
+
+# Story
+
+## Title: {name}
+
+## Genre
+
+{narrative_voice}
+
+# Character
+
+## Name
+
+{this_name}
+
+## Tagline
+
+{this_tagline}
+
+## Goal
+
+{adventure_goal}
+
+{this_description}
+
+## Background""",
 }
 
 
 class EditorSuggestionGenerator:
     def generate_editor_suggestion(
-        self, field_name: str, unsaved_server_settings: dict, context: AgentContext
+        self,
+        field_name: str,
+        unsaved_server_settings: dict,
+        field_key_path: List,
+        context: AgentContext,
     ) -> Task:
         server_settings = get_server_settings(context)
         generator = get_story_text_generator(context)
 
-        prompt = PROMPTS.get(field_name)
+        if len(field_key_path) == 1:
+            prompt_key = field_key_path[0]
+        elif len(field_key_path) == 3:
+            prompt_key = f"{field_key_path[0]}.{field_key_path[2]}"
+        else:
+            prompt_key = field_name
+
+        prompt = PROMPTS.get(prompt_key)
 
         if not prompt:
+            kp = ".".join(map(lambda x: f"{x}", field_key_path))
             raise SteamshipError(
-                message=f"Unable to generate a suggestion for {field_name}"
+                message=f"Unable to generate a suggestion for: {kp}. Lookup key: {prompt_key}"
             )
 
         # Now template it against the saved server settings
         variables = server_settings.dict()
         variables.update(unsaved_server_settings)
+
+        # The template interpolation assumes a FLAT object. But the object we're working with
+        # here might involve something nested (like the 3rd character). So we'll look at the keypath
+        # and lift those up to be represented as this_FIELD in the parent.
+        #
+        # That means the prompt can utilize this_{var} inside it.
+        if field_key_path and len(field_key_path) == 3:
+            # we'll just hard-code in the case for: [LIST_NAME, index, FIELD]
+            the_list = variables.get(field_key_path[0])
+            index = field_key_path[1]
+            if the_list and index < len(the_list):
+                variables["this_index"] = f"{index}"
+                for key in the_list[index]:
+                    variables[f"this_{key}"] = the_list[index][key]
 
         templated_prompt = safe_format(prompt, variables)
 

--- a/src/generators/editor_suggestions/editor_suggestion_generator.py
+++ b/src/generators/editor_suggestions/editor_suggestion_generator.py
@@ -1,165 +1,63 @@
-from typing import List
+from typing import Dict, List
 
-from steamship import SteamshipError, Task
+from steamship import Block, SteamshipError
 from steamship.agents.schema import AgentContext
 
-from generators.utils import safe_format
+from generators.editor_field_suggestion_generator import EditorFieldSuggestionGenerator
+from generators.editor_suggestions.adventure_background_suggestion import (
+    AdventureBackgroundSuggestionGenerator,
+)
+from generators.editor_suggestions.adventure_goal_suggestion import (
+    AdventureGoalSuggestionGenerator,
+)
+from generators.editor_suggestions.adventure_image_suggestion import (
+    AdventureImageSuggestionGenerator,
+)
+from generators.editor_suggestions.character_background_suggestion import (
+    CharacterBackgroundSuggestionGenerator,
+)
+from generators.editor_suggestions.character_description_suggestion import (
+    CharacterDescriptionSuggestionGenerator,
+)
+from generators.editor_suggestions.character_image_suggestion import (
+    CharacterImageSuggestionGenerator,
+)
+from generators.editor_suggestions.character_name_suggestion import (
+    CharacterNameSuggestionGenerator,
+)
+from generators.editor_suggestions.character_tagline_suggestion import (
+    CharacterTaglineSuggestionGenerator,
+)
+from generators.editor_suggestions.narrative_tone_suggestion import (
+    NarrativeToneSuggestionGenerator,
+)
+from generators.editor_suggestions.narrative_voice_suggestion import (
+    NarrativeVoiceSuggestionGenerator,
+)
 from utils.context_utils import get_server_settings, get_story_text_generator
-
-PROMPTS = {
-    # Note: this is "genre" in the UI
-    "narrative_voice": """Write a short genre suggestion for a story. Be expansive, creative, but concise!
-
-Examples of good outputs:
-
-- fantasy adventure
-- children’s book
-- young adult novel
-- fanfic
-- high literature
-
-Suggestion:
-
--""",
-    # Note: this is "writing style"
-    "narrative_tone": """Write a narrative tone suggestion for a story with the genre {narrative_voice}. Be creative! Wide-ranging! But keep it concise.
-
-Examples of good outputs:
-
-- silly, like a Cartoon Network show
-- parody, in the style of an HBO show
-- dramatic, with a tinge of danger
-- gritty, high contrast and real
-- film noir, with a romantic tinge of hard-boiled mystery
-
-Suggestion:
-
--""",
-    "adventure_background": """I need help! Write a few notes for a director about an scene in a short story.
-
-Be colorful, descriptive, but concise! Use Markdown and bullet points. Include the sections: tone, narrative voice, adventure background story, non-protagonist characters, locations, and important items to the story.
-
-## Genre
-
-{narrative_voice}
-
-## Writing Style
-
-{narrative_tone}
-
-""",
-    "adventure_goal": """I need help! Finish the main character goal for this short story.
-
-Be short! But creative and colorful. It needs to REALLY capture attention!
-
-Examples of riveting goals:
-- destroy the Ring of Elders
-- get into Harvard
-- escape from jail
-- create a company and take it to IPO
-- fall in love with a supermodel
-- pull off the world's greatest bank heist
-
-Here are the story details. Finish with the goal!
-
-## Genre
-
-{narrative_voice}
-
-## Writing Style
-
-{narrative_tone}
-
-{adventure_background}
-
-## Riveting Protagonist Goal:
--""",
-    "characters.name": """Suggest the name of Character #{this_index} in a story.
-
-Story Name: {name}
-Story Genre: {narrative_voice}
-Story Goal: {adventure_goal}
-Character ${this_index} name:""",
-    "characters.tagline": """Suggest short, 5-10 word tagline of Character #{this_index} in a story.
-
-Examples of good taglines illustrate the character's main motivation or struggle, ike this:
-
-- (Karate Girl) Knows the ropes. But does she know herself?
-- (Lawyer Sue) Sue everyone.
-- (Mr. Meatball) Become the biggest meatball.
-- (Dragonmaster) Ascend to the throne
-
-Story Name: {name}
-Story Genre: {narrative_voice}
-Story Goal: {adventure_goal}
-Character ${this_index} tagline: (${this_name}) """,
-    "characters.description": """Write notes for a novel character in markdown. Be concise but colorful. Use a few bullet points per section.
-
-Include the sections: Goal, Appearance, Skills, Struggles, Quirks
-
-# Story
-
-## Title: {name}
-
-## Genre
-
-{narrative_voice}
-
-# Character
-
-## Name
-
-{this_name}
-
-## Tagline
-
-{this_tagline}
-
-## Goal
-
-{adventure_goal}
-
-## Appearance""",
-    "characters.background": """Write notes for a novel character's background in markdown. The the character's goals are already developed.. the background should provide a riveting story of progress toward those goals!
-
-Be concise but colorful. Use a few bullet points per section.
-
-# Story
-
-## Title: {name}
-
-## Genre
-
-{narrative_voice}
-
-# Character
-
-## Name
-
-{this_name}
-
-## Tagline
-
-{this_tagline}
-
-## Goal
-
-{adventure_goal}
-
-{this_description}
-
-## Background""",
-}
 
 
 class EditorSuggestionGenerator:
+    PROMPTS: Dict[str, EditorFieldSuggestionGenerator] = {
+        NarrativeVoiceSuggestionGenerator.get_field(): NarrativeVoiceSuggestionGenerator(),
+        NarrativeToneSuggestionGenerator.get_field(): NarrativeToneSuggestionGenerator(),
+        CharacterTaglineSuggestionGenerator.get_field(): CharacterTaglineSuggestionGenerator(),
+        CharacterNameSuggestionGenerator.get_field(): CharacterNameSuggestionGenerator(),
+        CharacterDescriptionSuggestionGenerator.get_field(): CharacterDescriptionSuggestionGenerator(),
+        CharacterBackgroundSuggestionGenerator.get_field(): CharacterBackgroundSuggestionGenerator(),
+        CharacterImageSuggestionGenerator.get_field(): CharacterImageSuggestionGenerator(),
+        AdventureGoalSuggestionGenerator.get_field(): AdventureGoalSuggestionGenerator(),
+        AdventureBackgroundSuggestionGenerator.get_field(): AdventureBackgroundSuggestionGenerator(),
+        AdventureImageSuggestionGenerator.get_field(): AdventureImageSuggestionGenerator,
+    }
+
     def generate_editor_suggestion(
         self,
         field_name: str,
         unsaved_server_settings: dict,
         field_key_path: List,
         context: AgentContext,
-    ) -> Task:
+    ) -> Block:
         server_settings = get_server_settings(context)
         generator = get_story_text_generator(context)
 
@@ -170,7 +68,7 @@ class EditorSuggestionGenerator:
         else:
             prompt_key = field_name
 
-        prompt = PROMPTS.get(prompt_key)
+        prompt = self.PROMPTS.get(prompt_key)
 
         if not prompt:
             kp = ".".join(map(lambda x: f"{x}", field_key_path))
@@ -196,13 +94,4 @@ class EditorSuggestionGenerator:
                 for key in the_list[index]:
                     variables[f"this_{key}"] = the_list[index][key]
 
-        templated_prompt = safe_format(prompt, variables)
-
-        task = generator.generate(
-            text=templated_prompt,
-            streaming=True,
-            append_output_to_file=True,
-            make_output_public=True,
-        )
-        task.wait()
-        return task
+        return prompt.suggest(variables, generator, context)

--- a/src/generators/editor_suggestions/editor_suggestion_generator.py
+++ b/src/generators/editor_suggestions/editor_suggestion_generator.py
@@ -7,11 +7,20 @@ from generators.editor_field_suggestion_generator import EditorFieldSuggestionGe
 from generators.editor_suggestions.adventure_background_suggestion import (
     AdventureBackgroundSuggestionGenerator,
 )
+from generators.editor_suggestions.adventure_description_suggestion import (
+    AdventureDescriptionSuggestionGenerator,
+)
 from generators.editor_suggestions.adventure_goal_suggestion import (
     AdventureGoalSuggestionGenerator,
 )
 from generators.editor_suggestions.adventure_image_suggestion import (
     AdventureImageSuggestionGenerator,
+)
+from generators.editor_suggestions.adventure_name_suggestion import (
+    AdventureNameSuggestionGenerator,
+)
+from generators.editor_suggestions.adventure_short_description_suggestion import (
+    AdventureShortDescriptionSuggestionGenerator,
 )
 from generators.editor_suggestions.character_background_suggestion import (
     CharacterBackgroundSuggestionGenerator,
@@ -48,7 +57,10 @@ class EditorSuggestionGenerator:
         CharacterImageSuggestionGenerator.get_field(): CharacterImageSuggestionGenerator(),
         AdventureGoalSuggestionGenerator.get_field(): AdventureGoalSuggestionGenerator(),
         AdventureBackgroundSuggestionGenerator.get_field(): AdventureBackgroundSuggestionGenerator(),
-        AdventureImageSuggestionGenerator.get_field(): AdventureImageSuggestionGenerator,
+        AdventureImageSuggestionGenerator.get_field(): AdventureImageSuggestionGenerator(),
+        AdventureNameSuggestionGenerator.get_field(): AdventureNameSuggestionGenerator(),
+        AdventureShortDescriptionSuggestionGenerator.get_field(): AdventureShortDescriptionSuggestionGenerator(),
+        AdventureDescriptionSuggestionGenerator.get_field(): AdventureDescriptionSuggestionGenerator(),
     }
 
     def generate_editor_suggestion(
@@ -60,8 +72,9 @@ class EditorSuggestionGenerator:
     ) -> Block:
         server_settings = get_server_settings(context)
         generator = get_story_text_generator(context)
-
-        if len(field_key_path) == 1:
+        if not field_key_path:
+            prompt_key = field_name
+        elif len(field_key_path) == 1:
             prompt_key = field_key_path[0]
         elif len(field_key_path) == 3:
             prompt_key = f"{field_key_path[0]}.{field_key_path[2]}"
@@ -71,7 +84,10 @@ class EditorSuggestionGenerator:
         prompt = self.PROMPTS.get(prompt_key)
 
         if not prompt:
-            kp = ".".join(map(lambda x: f"{x}", field_key_path))
+            if field_key_path:
+                kp = ".".join(map(lambda x: f"{x}", field_key_path))
+            else:
+                kp = prompt_key
             raise SteamshipError(
                 message=f"Unable to generate a suggestion for: {kp}. Lookup key: {prompt_key}"
             )

--- a/src/generators/editor_suggestions/editor_suggestion_generator.py
+++ b/src/generators/editor_suggestions/editor_suggestion_generator.py
@@ -75,9 +75,10 @@ class EditorSuggestionGenerator:
         if not field_key_path:
             prompt_key = field_name
         elif len(field_key_path) == 1:
-            prompt_key = field_key_path[0]
+            prompt_key = field_name
         elif len(field_key_path) == 3:
-            prompt_key = f"{field_key_path[0]}.{field_key_path[2]}"
+            # Note: it's important this last bit is field_name because of some strange bits in the client
+            prompt_key = f"{field_key_path[0]}.{field_name}"
         else:
             prompt_key = field_name
 

--- a/src/generators/editor_suggestions/narrative_tone_suggestion.py
+++ b/src/generators/editor_suggestions/narrative_tone_suggestion.py
@@ -1,0 +1,36 @@
+from steamship import Block, PluginInstance
+from steamship.agents.schema import AgentContext
+
+from generators.editor_field_suggestion_generator import EditorFieldSuggestionGenerator
+from generators.utils import safe_format
+
+
+class NarrativeToneSuggestionGenerator(EditorFieldSuggestionGenerator):
+    PROMPT = """Write a narrative tone suggestion for a story with the genre {narrative_voice}. Be creative! Wide-ranging! But keep it concise.
+
+Examples of good outputs:
+
+- silly, like a Cartoon Network show
+- parody, in the style of an HBO show
+- dramatic, with a tinge of danger
+- gritty, high contrast and real
+- film noir, with a romantic tinge of hard-boiled mystery
+
+Suggestion:
+
+-"""
+
+    @staticmethod
+    def get_field() -> str:
+        return "narrative_tone"
+
+    def suggest(
+        self, variables: dict, generator: PluginInstance, context: AgentContext
+    ) -> Block:
+        task = generator.generate(
+            text=safe_format(self.PROMPT, variables),
+            streaming=True,
+            append_output_to_file=True,
+            make_output_public=True,
+        )
+        return self.task_to_str_block(task)

--- a/src/generators/editor_suggestions/narrative_voice_suggestion.py
+++ b/src/generators/editor_suggestions/narrative_voice_suggestion.py
@@ -1,0 +1,36 @@
+from steamship import Block, PluginInstance
+from steamship.agents.schema import AgentContext
+
+from generators.editor_field_suggestion_generator import EditorFieldSuggestionGenerator
+from generators.utils import safe_format
+
+
+class NarrativeVoiceSuggestionGenerator(EditorFieldSuggestionGenerator):
+    PROMPT = """Write a short genre suggestion for a story. Be expansive, creative, but concise!
+
+Examples of good outputs:
+
+- fantasy adventure
+- children’s book
+- young adult novel
+- fanfic
+- high literature
+
+Suggestion:
+
+-"""
+
+    @staticmethod
+    def get_field() -> str:
+        return "narrative_voice"
+
+    def suggest(
+        self, variables: dict, generator: PluginInstance, context: AgentContext
+    ) -> Block:
+        task = generator.generate(
+            text=safe_format(self.PROMPT, variables),
+            streaming=True,
+            append_output_to_file=True,
+            make_output_public=True,
+        )
+        return self.task_to_str_block(task)

--- a/src/generators/generator_context_utils.py
+++ b/src/generators/generator_context_utils.py
@@ -8,8 +8,7 @@ from generators.music_generator import MusicGenerator
 from generators.music_generators.meta_music_generator import MetaMusicGenerator
 from generators.social_media.haiku_tweet_generator import HaikuTweetGenerator
 from generators.social_media_generator import SocialMediaGenerator
-from schema.server_settings import get_theme
-from utils.context_utils import get_server_settings
+from utils.context_utils import get_server_settings, get_theme
 
 _CAMP_IMAGE_GENERATOR_KEY = "camp-image-generator"
 _ITEM_IMAGE_GENERATOR_KEY = "item-image-generator"

--- a/src/generators/image_generator.py
+++ b/src/generators/image_generator.py
@@ -25,3 +25,7 @@ class ImageGenerator(BaseModel, ABC):
     @abstractmethod
     def request_camp_image_generation(self, context: AgentContext) -> Task:
         pass
+
+    @abstractmethod
+    def request_adventure_image_generation(self, context: AgentContext) -> Task:
+        pass

--- a/src/generators/image_generators/dalle.py
+++ b/src/generators/image_generators/dalle.py
@@ -47,6 +47,11 @@ class DalleImageGenerator(ImageGenerator):
             "style": theme.style,
         }
 
+        # Fixes for DALL-E 2 which only supports squares.
+        # TODO: Find a way to talk about image sizes that works across models. Maybe just have three options: default, portrait, landscape?
+        if theme.model == "dall-e-2":
+            image_size = "1024x1024"
+
         # TODO(doug): cache plugin instance by client workspace
         dalle = context.client.use_plugin(
             DalleImageGenerator.PLUGIN_HANDLE,

--- a/src/generators/image_generators/dalle.py
+++ b/src/generators/image_generators/dalle.py
@@ -177,3 +177,22 @@ class DalleImageGenerator(ImageGenerator):
         )
         task.wait()
         return task
+
+    def request_adventure_image_generation(self, context: AgentContext) -> Task:
+        server_settings = get_server_settings(context)
+
+        tags = []
+
+        task = self.generate(
+            context=context,
+            theme_name=server_settings.camp_image_theme,
+            prompt="Cinematic, 8k, movie advertising image, {narrative_voice}, Movie Title: {name}",
+            template_vars={
+                "narrative_voice": server_settings.narrative_voice,
+                "name": server_settings.name,
+            },
+            image_size="1024x1792",
+            tags=tags,
+        )
+        task.wait()
+        return task

--- a/src/generators/image_generators/stable_diffusion_with_loras.py
+++ b/src/generators/image_generators/stable_diffusion_with_loras.py
@@ -191,3 +191,23 @@ class StableDiffusionWithLorasImageGenerator(ImageGenerator):
         )
         task.wait()
         return task
+
+    def request_adventure_image_generation(self, context: AgentContext) -> Task:
+        server_settings = get_server_settings(context)
+
+        tags = []
+
+        task = self.generate(
+            context=context,
+            theme_name=server_settings.camp_image_theme,
+            prompt="Cinematic, 8k, movie advertising image, {narrative_voice}, Movie Title: {name}",
+            negative_prompt="",
+            template_vars={
+                "narrative_voice": server_settings.narrative_voice,
+                "name": server_settings.name,
+            },
+            image_size="portrait_4_3",
+            tags=tags,
+        )
+        task.wait()
+        return task

--- a/src/schema/image_theme.py
+++ b/src/schema/image_theme.py
@@ -222,7 +222,6 @@ EPIC_REALISM = StableDiffusionTheme(
     clip_skip=0,
 )
 
-
 DALL_E_3_VIVID_STANDARD = DalleTheme(
     name="dall_e_3_vivid_standard",
     model="dall-e-3",

--- a/src/schema/image_theme.py
+++ b/src/schema/image_theme.py
@@ -72,6 +72,11 @@ class DalleTheme(ImageTheme):
         "This param is only supported for `dall-e-3`.",
     )
 
+    image_size: str = Field(
+        "1024x1024",
+        description="The size of the generated image(s). For Dalle2: ['256x256', '512x512', '1024x1024']. For DALL-E 3: ['1024×1024', '1024×1792', '1792×1024']",
+    )
+
     # TODO(dougreid): add validation for style and quality
 
 
@@ -250,6 +255,29 @@ DALL_E_3_NATURAL_HD = DalleTheme(
     quality="hd",
 )
 
+
+DALL_E_2_STANDARD = DalleTheme(
+    name="dall_e_2_vivid_standard",
+    model="dall-e-2",
+    quality="standard",
+)
+
+DALL_E_2_STELLAR_DREAMS = DalleTheme(
+    name="dall_e_2_stellar_dream",
+    model="dall-e-2",
+    prompt_prefix="Surreal painting, ",
+    prompt_suffix="; using soft, dreamy colors and elements of fantasy",
+    quality="standard",
+)
+
+DALL_E_2_NEON_CYBERPUNK = DalleTheme(
+    name="dall_e_2_neon_cyberpunk",
+    model="dall-e-2",
+    prompt_prefix="Cyberpunk, digital art, best quality, neon-lit, ",
+    prompt_suffix="; high contrast, blending traditional and futuristic",
+    quality="standard",
+)
+
 # Premade themes that we know work well
 PREMADE_THEMES = [
     PIXEL_ART_THEME_1,
@@ -262,6 +290,9 @@ PREMADE_THEMES = [
     DALL_E_3_NATURAL_STANDARD,
     DALL_E_3_VIVID_HD,
     DALL_E_3_VIVID_STANDARD,
+    DALL_E_2_STANDARD,
+    DALL_E_2_STELLAR_DREAMS,
+    DALL_E_2_NEON_CYBERPUNK,
 ]
 
 DEFAULT_THEME = PIXEL_ART_THEME_2

--- a/src/schema/server_settings.py
+++ b/src/schema/server_settings.py
@@ -112,6 +112,12 @@ class ServerSettings(BaseModel):
     # Narration Generation Settings
     default_narration_model: str = Field("elevenlabs", description="")
 
+    # Name
+    name: str = Field(
+        default="My Adventure",
+        description="What is the name of the story?",
+    )
+
     # Narrative settings
     narrative_tone: str = Field(
         default="silly",

--- a/src/schema/server_settings.py
+++ b/src/schema/server_settings.py
@@ -113,9 +113,14 @@ class ServerSettings(BaseModel):
     default_narration_model: str = Field("elevenlabs", description="")
 
     # Name
-    name: str = Field(
+    name: Optional[str] = Field(
         default="My Adventure",
         description="What is the name of the story?",
+    )
+
+    short_description: Optional[str] = Field(
+        default="An amazing story of exploration.",
+        description="What is a short, 4-8 word description of the story?",
     )
 
     # Narrative settings

--- a/steamship.json
+++ b/steamship.json
@@ -1,7 +1,7 @@
 {
 	"type": "package",
 	"handle": "ai-adventure",
-	"version": "1.0.4-rc.46",
+	"version": "1.0.4-rc.47",
 	"description": "",
 	"author": "",
 	"entrypoint": "Unused",

--- a/steamship.json
+++ b/steamship.json
@@ -1,7 +1,7 @@
 {
 	"type": "package",
 	"handle": "ai-adventure",
-	"version": "1.0.4-rc.45",
+	"version": "1.0.4-rc.46",
 	"description": "",
 	"author": "",
 	"entrypoint": "Unused",

--- a/steamship.json
+++ b/steamship.json
@@ -1,7 +1,7 @@
 {
 	"type": "package",
 	"handle": "ai-adventure",
-	"version": "1.0.4-rc.48",
+	"version": "1.0.4-rc.49",
 	"description": "",
 	"author": "",
 	"entrypoint": "Unused",

--- a/steamship.json
+++ b/steamship.json
@@ -1,7 +1,7 @@
 {
 	"type": "package",
 	"handle": "ai-adventure",
-	"version": "1.0.4-rc.47",
+	"version": "1.0.4-rc.48",
 	"description": "",
 	"author": "",
 	"entrypoint": "Unused",

--- a/steamship.json
+++ b/steamship.json
@@ -1,7 +1,7 @@
 {
 	"type": "package",
 	"handle": "ai-adventure",
-	"version": "1.0.4-rc.27",
+	"version": "1.0.4-rc.44",
 	"description": "",
 	"author": "",
 	"entrypoint": "Unused",

--- a/steamship.json
+++ b/steamship.json
@@ -1,7 +1,7 @@
 {
 	"type": "package",
 	"handle": "ai-adventure",
-	"version": "1.0.4-rc.44",
+	"version": "1.0.4-rc.45",
 	"description": "",
 	"author": "",
 	"entrypoint": "Unused",

--- a/steamship.json
+++ b/steamship.json
@@ -1,7 +1,7 @@
 {
 	"type": "package",
 	"handle": "ai-adventure",
-	"version": "1.0.4-rc.50",
+	"version": "1.0.4-rc.51",
 	"description": "",
 	"author": "",
 	"entrypoint": "Unused",

--- a/steamship.json
+++ b/steamship.json
@@ -1,7 +1,7 @@
 {
 	"type": "package",
 	"handle": "ai-adventure",
-	"version": "1.0.4-rc.49",
+	"version": "1.0.4-rc.50",
 	"description": "",
 	"author": "",
 	"entrypoint": "Unused",

--- a/tests/steamship_tests/endpoints/test_game_editor_endpoints.py
+++ b/tests/steamship_tests/endpoints/test_game_editor_endpoints.py
@@ -41,3 +41,27 @@ def test_generate_suggestion(
     url = f"{client.config.api_base}block/{block.id}/raw"
     response = requests.get(url)
     assert response.ok
+
+
+@pytest.mark.parametrize(
+    "invocable_handler_with_client", [AdventureGameService], indirect=True
+)
+def test_generate_character_suggestion(
+    invocable_handler_with_client: Tuple[
+        Callable[[str, str, Optional[dict]], dict], Steamship
+    ]
+):
+    invocable_handler, client = invocable_handler_with_client
+    task_dict = invocable_handler(
+        "POST",
+        "generate_suggestion",
+        {"field_name": "name", "field_key_path": ["characters", 0, "name"]},
+    )
+    block = Block.parse_obj(task_dict.get("data"))
+    if block.text:
+        print(block.text)
+        return
+
+    url = f"{client.config.api_base}block/{block.id}/raw"
+    response = requests.get(url)
+    assert response.ok

--- a/tests/steamship_tests/endpoints/test_game_editor_endpoints.py
+++ b/tests/steamship_tests/endpoints/test_game_editor_endpoints.py
@@ -65,6 +65,22 @@ def test_generate_suggestion(
 @pytest.mark.parametrize(
     "invocable_handler_with_client", [AdventureGameService], indirect=True
 )
+def test_generate_suggestion_adventure_name(
+    invocable_handler_with_client: Tuple[
+        Callable[[str, str, Optional[dict]], dict], Steamship
+    ]
+):
+    invocable_handler, client = invocable_handler_with_client
+    task_dict = invocable_handler("POST", "generate_suggestion", {"field_name": "name"})
+    block = Block.parse_obj(task_dict.get("data"))
+    url = f"{client.config.api_base}block/{block.id}/raw"
+    response = requests.get(url)
+    assert response.ok
+
+
+@pytest.mark.parametrize(
+    "invocable_handler_with_client", [AdventureGameService], indirect=True
+)
 def test_generate_character_suggestion(
     invocable_handler_with_client: Tuple[
         Callable[[str, str, Optional[dict]], dict], Steamship

--- a/tests/steamship_tests/endpoints/test_game_editor_endpoints.py
+++ b/tests/steamship_tests/endpoints/test_game_editor_endpoints.py
@@ -10,6 +10,25 @@ from api import AdventureGameService
 @pytest.mark.parametrize(
     "invocable_handler_with_client", [AdventureGameService], indirect=True
 )
+def test_generate_adventure_image_suggestion(
+    invocable_handler_with_client: Tuple[
+        Callable[[str, str, Optional[dict]], dict], Steamship
+    ]
+):
+    invocable_handler, client = invocable_handler_with_client
+    task_dict = invocable_handler(
+        "POST", "generate_suggestion", {"field_name": "adventure_image"}
+    )
+    block = Block.parse_obj(task_dict.get("data"))
+
+    url = f"{client.config.api_base}block/{block.id}/raw"
+    response = requests.get(url)
+    assert response.ok
+
+
+@pytest.mark.parametrize(
+    "invocable_handler_with_client", [AdventureGameService], indirect=True
+)
 def test_generate_preview(
     invocable_handler_with_client: Tuple[
         Callable[[str, str, Optional[dict]], dict], Steamship
@@ -61,6 +80,27 @@ def test_generate_character_suggestion(
     if block.text:
         print(block.text)
         return
+
+    url = f"{client.config.api_base}block/{block.id}/raw"
+    response = requests.get(url)
+    assert response.ok
+
+
+@pytest.mark.parametrize(
+    "invocable_handler_with_client", [AdventureGameService], indirect=True
+)
+def test_generate_character_image_suggestion(
+    invocable_handler_with_client: Tuple[
+        Callable[[str, str, Optional[dict]], dict], Steamship
+    ]
+):
+    invocable_handler, client = invocable_handler_with_client
+    task_dict = invocable_handler(
+        "POST",
+        "generate_suggestion",
+        {"field_name": "name", "field_key_path": ["characters", 0, "image"]},
+    )
+    block = Block.parse_obj(task_dict.get("data"))
 
     url = f"{client.config.api_base}block/{block.id}/raw"
     response = requests.get(url)

--- a/tests/steamship_tests/generators/image_generators/test_dalle.py
+++ b/tests/steamship_tests/generators/image_generators/test_dalle.py
@@ -7,6 +7,7 @@ from utils.context_utils import (
     get_game_state,
     get_server_settings,
     get_theme,
+    save_game_state,
     save_server_settings,
 )
 
@@ -18,18 +19,19 @@ def test_profile_pic_generation(client: Steamship):
     )
     gs = get_game_state(context)
 
-    gs.player.name = "PICKLE MAN"
-    gs.player.description = "A pickle as tall as a building that wears suspenders."
+    gs.player.name = "Superhero Dog"
+    gs.player.description = "A golden retriever in a superman cape."
+    save_game_state(gs, context)
 
     ss = get_server_settings(context)
-    ss.profile_image_theme = "dall_e_3_vivid_standard"
-
-    ss.profile_image_prompt = "Richard Stallman at y combinator headquarters"
+    ss.profile_image_theme = "dall_e_2_neon_cyberpunk"
+    ss.profile_image_prompt = (
+        "{name}, {description}. Close-up on head. Gradient background."
+    )
     save_server_settings(ss, context)
 
     theme = get_theme(ss.profile_image_theme, context)
     generator = get_image_generator(theme)
-
     task = generator.request_profile_image_generation(context)
 
     task.wait()


### PR DESCRIPTION
Generating suggestions requires more than just a string prompt with variables - sometimes a bit of python or string hackery is necessary.

This PR:

1. Creates a class that enables that, per-suggestion
2. Adds suggestions for several adventure fields (name, desc, short desc, etc)
3. Adds suggestions for character fields
4. Adds suggestions for character images.

NOTE!

Iteration on these prompts will be necessary. This PR is aiming to establish a solid groundwork on which to do that. 