### PR TITLE
add character image preview that uses name and description

### DIFF
--- a/src/generators/image_generator.py
+++ b/src/generators/image_generator.py
@@ -29,3 +29,10 @@ class ImageGenerator(BaseModel, ABC):
     @abstractmethod
     def request_adventure_image_generation(self, context: AgentContext) -> Task:
         pass
+
+    @abstractmethod
+    def request_character_image_generation(
+        self, name: str, description: str, context: AgentContext
+    ) -> Task:
+        """Request character image generation. This is for static generation from the editor."""
+        pass

--- a/src/generators/image_generators/dalle.py
+++ b/src/generators/image_generators/dalle.py
@@ -137,6 +137,27 @@ class DalleImageGenerator(ImageGenerator):
         task.wait()
         return task
 
+    def request_character_image_generation(
+        self, name: str, description: str, context: AgentContext
+    ) -> Task:
+        server_settings = get_server_settings(context)
+        task = self.generate(
+            context=context,
+            theme_name=server_settings.profile_image_theme,
+            prompt=server_settings.profile_image_prompt,
+            template_vars={
+                "name": name,
+                "tone": server_settings.narrative_tone,
+                "genre": server_settings.narrative_voice,
+                "description": description,
+            },
+            image_size="1024x1792",
+            tags=[],  # no tags, as this is strictly for in-editor usage.
+        )
+
+        task.wait()
+        return task
+
     def request_scene_image_generation(
         self, description: str, context: AgentContext
     ) -> Task:

--- a/src/generators/image_generators/stable_diffusion_with_loras.py
+++ b/src/generators/image_generators/stable_diffusion_with_loras.py
@@ -145,6 +145,28 @@ class StableDiffusionWithLorasImageGenerator(ImageGenerator):
         task.wait()
         return task
 
+    def request_character_image_generation(
+        self, name: str, description: str, context: AgentContext
+    ) -> Task:
+        server_settings = get_server_settings(context)
+        task = self.generate(
+            context=context,
+            theme_name=server_settings.profile_image_theme,
+            prompt=server_settings.profile_image_prompt,
+            negative_prompt=server_settings.profile_image_negative_prompt,
+            template_vars={
+                "name": name,
+                "tone": server_settings.narrative_tone,
+                "genre": server_settings.narrative_voice,
+                "description": description,
+            },
+            image_size="portrait_4_3",
+            tags=[],  # no tags, as this shouldn't be used in chathistory for anything else (at the moment)
+        )
+
+        task.wait()
+        return task
+
     def request_scene_image_generation(
         self, description: str, context: AgentContext
     ) -> Task:

--- a/src/generators/server_settings_field_generators/character_description_generator.py
+++ b/src/generators/server_settings_field_generators/character_description_generator.py
@@ -39,7 +39,7 @@ Character Physical Description (one line):"""
                     "short_description": variables.get("short_description"),
                     "narrative_voice": variables.get("narrative_voice"),
                     "narrative_tone": variables.get("narrative_tone"),
-                    "this_name": variables.get("this_index"),
+                    "this_name": variables.get("this_name"),
                     "this_tagline": variables.get("this_tagline"),
                     "this_background": variables.get("this_background"),
                 },

--- a/src/generators/server_settings_field_generators/character_image_generator.py
+++ b/src/generators/server_settings_field_generators/character_image_generator.py
@@ -19,7 +19,12 @@ class CharacterImageGenerator(ServerSettingsFieldGenerator):
         context: AgentContext,
         generation_config: Optional[dict] = None,
     ) -> Block:
+
+        name = variables.get("this_name", "")
+        description = variables.get("this_description", "")
         generator = get_profile_image_generator(context)
-        task = generator.request_profile_image_generation(context)
+        task = generator.request_character_image_generation(
+            name=name, description=description, context=context
+        )
         task.wait()
         return task.output.blocks[0]

--- a/src/schema/image_theme.py
+++ b/src/schema/image_theme.py
@@ -30,7 +30,7 @@ class ImageTheme(BaseModel):
 
     def make_prompt(self, prompt: str, prompt_params: Optional[dict] = None):
         """Applies the included suffixes and then interpolates any {referenced} variables."""
-        template = f"{self.prompt_prefix or ''}{prompt}{self.prompt_suffix or ''}"
+        template = f"{self.prompt_prefix or ''} {prompt} {self.prompt_suffix or ''}"
         return safe_format(template, prompt_params or {})
 
     @property

--- a/tests/steamship_tests/endpoints/test_adventure_template_endpoints.py
+++ b/tests/steamship_tests/endpoints/test_adventure_template_endpoints.py
@@ -130,7 +130,7 @@ def test_generate_character_suggestion(
 @pytest.mark.parametrize(
     "invocable_handler_with_client", [AdventureGameService], indirect=True
 )
-def test_generate_character_image_suggestion(
+def test_generate_character_image_suggestion_dalle(
     invocable_handler_with_client: Tuple[
         Callable[[str, str, Optional[dict]], dict], Steamship
     ]
@@ -139,7 +139,56 @@ def test_generate_character_image_suggestion(
     task_dict = invocable_handler(
         "POST",
         "generate_suggestion",
-        {"field_name": "name", "field_key_path": ["characters", 0, "image"]},
+        {
+            "field_name": "name",
+            "field_key_path": ["characters", 0, "image"],
+            "unsaved_server_settings": {
+                "profile_image_theme": "dall_e_2_neon_cyberpunk",
+                "characters": [
+                    {
+                        "name": "Mr. Meatball",
+                        "description": "Giant friendly monster made of meatballs and cheese",
+                    }
+                ],
+            },
+        },
+    )
+    block = Block.parse_obj(task_dict.get("data"))
+
+    url = f"{client.config.api_base}block/{block.id}/raw"
+    response = requests.get(url)
+    assert response.ok
+
+
+@pytest.mark.parametrize(
+    "invocable_handler_with_client", [AdventureGameService], indirect=True
+)
+def test_generate_character_image_suggestion_stable_diffusion(
+    invocable_handler_with_client: Tuple[
+        Callable[[str, str, Optional[dict]], dict], Steamship
+    ]
+):
+    invocable_handler, client = invocable_handler_with_client
+    task_dict = invocable_handler(
+        "POST",
+        "generate_suggestion",
+        {
+            "field_name": "name",
+            "field_key_path": ["characters", 1, "image"],
+            "unsaved_server_settings": {
+                "profile_image_theme": "stable_diffusion_xl_no_loras",
+                "characters": [
+                    {
+                        "name": "Mr. Meatball",
+                        "description": "Giant friendly monster made of meatballs and cheese",
+                    },
+                    {
+                        "name": "Mike Mechanic",
+                        "description": "strong (handsome) blue-haired, always wears overalls",
+                    },
+                ],
+            },
+        },
     )
     block = Block.parse_obj(task_dict.get("data"))
 


### PR DESCRIPTION
This PR should enable the agent to use the `name` and `description` supplied by a user in the generation of a character image (within the editor).