### PR TITLE
Speed up onboarding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ logs/
 .pytest_cache
 harness_output/**/*.txt
 harness_output/**/*.md
+src/.steamship/secrets.toml

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ steamship==2.17.32
 pydantic==1.10.13
 pydantic-yaml==1.2.0
 beautifulsoup4==4.12.2
+openai==0.27.8

--- a/src/agents/onboarding_agent.py
+++ b/src/agents/onboarding_agent.py
@@ -28,15 +28,10 @@ from utils.tags import CharacterTag, InstructionsTag, StoryContextTag, TagKindEx
 def _is_allowed_by_moderation(user_input: str, openai_api_key: str) -> bool:
     start = time.perf_counter()
     openai.api_key = openai_api_key
-    try:
-        moderation = openai.Moderation.create(input=user_input)
-        result = moderation["results"][0]["flagged"]
-        logging.debug(f"One moderation: {time.perf_counter() - start}")
-        return not result
-    except Exception as e:
-        if "flagged" in str(e):
-            return False
-        return True
+    moderation = openai.Moderation.create(input=user_input)
+    result = moderation["results"][0]["flagged"]
+    logging.debug(f"One moderation: {time.perf_counter() - start}")
+    return not result
 
 
 class OnboardingAgent(InterruptiblePythonAgent):

--- a/src/agents/onboarding_agent.py
+++ b/src/agents/onboarding_agent.py
@@ -1,3 +1,5 @@
+import time
+
 from steamship import Block, MimeTypes, Tag
 from steamship.agents.schema import Action, AgentContext
 from steamship.agents.schema.action import FinishAction
@@ -23,10 +25,12 @@ from utils.tags import CharacterTag, InstructionsTag, StoryContextTag, TagKindEx
 
 
 def _is_allowed_by_moderation(user_input: str, context: AgentContext) -> bool:
+    start = time.perf_counter()
     generator = get_story_text_generator(context)
     try:
         task = generator.generate(text=user_input)
         task.wait()
+        print(f"One moderation: {time.perf_counter() - start}")
         return True
     except Exception as e:
         if "flagged" in str(e):

--- a/src/api.py
+++ b/src/api.py
@@ -125,6 +125,10 @@ class AdventureGameService(AgentService):
             "pNInz6obpgDQGcFmaJgB",
             description="[Optional] ElevenLabs voice ID (default: Adam)",
         )
+        openai_api_key: str = Field(
+            "",
+            description="An openAI API key to use. If left default, will use Steamship's API key.",
+        )
 
     config: BasicAgentServiceConfig
     """The configuration block that users who create an instance of this agent will provide."""
@@ -198,7 +202,11 @@ class AdventureGameService(AgentService):
         )
 
         self.add_mixin(
-            OnboardingMixin(client=self.client, agent_service=cast(AgentService, self))
+            OnboardingMixin(
+                client=self.client,
+                agent_service=cast(AgentService, self),
+                openai_api_key=self.config.openai_api_key,
+            )
         )
 
         self.add_mixin(
@@ -209,7 +217,10 @@ class AdventureGameService(AgentService):
         function_capable_llm = ChatOpenAI(self.client)
 
         self.onboarding_agent = OnboardingAgent(
-            client=self.client, tools=[], llm=function_capable_llm
+            client=self.client,
+            tools=[],
+            llm=function_capable_llm,
+            openai_api_key=self.config.openai_api_key,
         )
         self.quest_agent = QuestAgent(tools=[], llm=function_capable_llm)
         self.camp_agent = CampAgent(llm=function_capable_llm)

--- a/src/endpoints/onboarding_endpoints.py
+++ b/src/endpoints/onboarding_endpoints.py
@@ -1,4 +1,5 @@
 import logging
+import time
 from typing import Optional
 
 from steamship import Steamship, SteamshipError
@@ -91,9 +92,11 @@ class OnboardingMixin(PackageMixin):
             game_state = get_game_state(context)
 
             # TODO: streamline for mass validation ?
+            moderation_start = time.perf_counter()
             self.set_character_name(game_state.player.name)
             self.set_character_background(game_state.player.background)
             self.set_character_description(game_state.player.description)
+            print(f"Moderation time: {time.perf_counter() - moderation_start}")
 
             game_state = get_game_state(context)
 

--- a/tests/steamship_tests/endpoints/test_quest_endpoints.py
+++ b/tests/steamship_tests/endpoints/test_quest_endpoints.py
@@ -48,20 +48,14 @@ def test_calling_start_quest_causes_active_quest(
     game_state: GameState = GameState.parse_obj(
         invocable_handler("GET", "game_state", {}).get("data")
     )
-    assert game_state.tone
-    assert game_state.genre
     assert game_state.player.name
     assert game_state.player.description
     assert game_state.player.background
-    assert game_state.player.motivation
     assert game_state.player.inventory
 
-    assert game_state.tone == COMPLETED_ONBOARDING.tone
-    assert game_state.genre == COMPLETED_ONBOARDING.genre
     assert game_state.player.name == COMPLETED_ONBOARDING.player.name
     assert game_state.player.description == COMPLETED_ONBOARDING.player.description
     assert game_state.player.background == COMPLETED_ONBOARDING.player.background
-    assert game_state.player.motivation == COMPLETED_ONBOARDING.player.motivation
     assert game_state.player.inventory == COMPLETED_ONBOARDING.player.inventory
 
     assert game_state.current_quest

--- a/tests/steamship_tests/endpoints/test_quest_endpoints.py
+++ b/tests/steamship_tests/endpoints/test_quest_endpoints.py
@@ -1,4 +1,3 @@
-import time
 from typing import Callable, Optional, Tuple
 
 import pytest
@@ -39,37 +38,34 @@ def test_calling_start_quest_causes_active_quest(
 
     invocable_handler("POST", "game_state", COMPLETED_ONBOARDING.dict())
 
-    start_time = time.perf_counter()
     invocable_handler("POST", "complete_onboarding", {})
 
-    onboarding_duration = time.perf_counter() - start_time
-    print(f"Onboarding duration: {onboarding_duration}")
-    # start_state = invocable_handler("POST", "start_quest", {})
-    # assert start_state.get("data")
-    # quest: Quest = Quest.parse_obj(start_state.get("data"))
-    # assert quest.name
-    #
-    # game_state: GameState = GameState.parse_obj(
-    #     invocable_handler("GET", "game_state", {}).get("data")
-    # )
-    # assert game_state.tone
-    # assert game_state.genre
-    # assert game_state.player.name
-    # assert game_state.player.description
-    # assert game_state.player.background
-    # assert game_state.player.motivation
-    # assert game_state.player.inventory
-    #
-    # assert game_state.tone == COMPLETED_ONBOARDING.tone
-    # assert game_state.genre == COMPLETED_ONBOARDING.genre
-    # assert game_state.player.name == COMPLETED_ONBOARDING.player.name
-    # assert game_state.player.description == COMPLETED_ONBOARDING.player.description
-    # assert game_state.player.background == COMPLETED_ONBOARDING.player.background
-    # assert game_state.player.motivation == COMPLETED_ONBOARDING.player.motivation
-    # assert game_state.player.inventory == COMPLETED_ONBOARDING.player.inventory
-    #
-    # assert game_state.current_quest
-    # assert game_state.active_mode.value == ActiveMode.QUEST.value
+    start_state = invocable_handler("POST", "start_quest", {})
+    assert start_state.get("data")
+    quest: Quest = Quest.parse_obj(start_state.get("data"))
+    assert quest.name
+
+    game_state: GameState = GameState.parse_obj(
+        invocable_handler("GET", "game_state", {}).get("data")
+    )
+    assert game_state.tone
+    assert game_state.genre
+    assert game_state.player.name
+    assert game_state.player.description
+    assert game_state.player.background
+    assert game_state.player.motivation
+    assert game_state.player.inventory
+
+    assert game_state.tone == COMPLETED_ONBOARDING.tone
+    assert game_state.genre == COMPLETED_ONBOARDING.genre
+    assert game_state.player.name == COMPLETED_ONBOARDING.player.name
+    assert game_state.player.description == COMPLETED_ONBOARDING.player.description
+    assert game_state.player.background == COMPLETED_ONBOARDING.player.background
+    assert game_state.player.motivation == COMPLETED_ONBOARDING.player.motivation
+    assert game_state.player.inventory == COMPLETED_ONBOARDING.player.inventory
+
+    assert game_state.current_quest
+    assert game_state.active_mode.value == ActiveMode.QUEST.value
 
 
 @pytest.mark.parametrize("invocable_handler", [AdventureGameService], indirect=True)

--- a/tests/steamship_tests/endpoints/test_quest_endpoints.py
+++ b/tests/steamship_tests/endpoints/test_quest_endpoints.py
@@ -1,3 +1,4 @@
+import time
 from typing import Callable, Optional, Tuple
 
 import pytest
@@ -30,7 +31,6 @@ COMPLETED_ONBOARDING: GameState = GameState.parse_obj(
 def test_calling_start_quest_causes_active_quest(
     invocable_handler: Callable[[str, str, Optional[dict]], dict]
 ):
-
     game_state: GameState = GameState.parse_obj(
         invocable_handler("GET", "game_state", {}).get("data")
     )
@@ -39,34 +39,37 @@ def test_calling_start_quest_causes_active_quest(
 
     invocable_handler("POST", "game_state", COMPLETED_ONBOARDING.dict())
 
+    start_time = time.perf_counter()
     invocable_handler("POST", "complete_onboarding", {})
 
-    start_state = invocable_handler("POST", "start_quest", {})
-    assert start_state.get("data")
-    quest: Quest = Quest.parse_obj(start_state.get("data"))
-    assert quest.name
-
-    game_state: GameState = GameState.parse_obj(
-        invocable_handler("GET", "game_state", {}).get("data")
-    )
-    assert game_state.tone
-    assert game_state.genre
-    assert game_state.player.name
-    assert game_state.player.description
-    assert game_state.player.background
-    assert game_state.player.motivation
-    assert game_state.player.inventory
-
-    assert game_state.tone == COMPLETED_ONBOARDING.tone
-    assert game_state.genre == COMPLETED_ONBOARDING.genre
-    assert game_state.player.name == COMPLETED_ONBOARDING.player.name
-    assert game_state.player.description == COMPLETED_ONBOARDING.player.description
-    assert game_state.player.background == COMPLETED_ONBOARDING.player.background
-    assert game_state.player.motivation == COMPLETED_ONBOARDING.player.motivation
-    assert game_state.player.inventory == COMPLETED_ONBOARDING.player.inventory
-
-    assert game_state.current_quest
-    assert game_state.active_mode.value == ActiveMode.QUEST.value
+    onboarding_duration = time.perf_counter() - start_time
+    print(f"Onboarding duration: {onboarding_duration}")
+    # start_state = invocable_handler("POST", "start_quest", {})
+    # assert start_state.get("data")
+    # quest: Quest = Quest.parse_obj(start_state.get("data"))
+    # assert quest.name
+    #
+    # game_state: GameState = GameState.parse_obj(
+    #     invocable_handler("GET", "game_state", {}).get("data")
+    # )
+    # assert game_state.tone
+    # assert game_state.genre
+    # assert game_state.player.name
+    # assert game_state.player.description
+    # assert game_state.player.background
+    # assert game_state.player.motivation
+    # assert game_state.player.inventory
+    #
+    # assert game_state.tone == COMPLETED_ONBOARDING.tone
+    # assert game_state.genre == COMPLETED_ONBOARDING.genre
+    # assert game_state.player.name == COMPLETED_ONBOARDING.player.name
+    # assert game_state.player.description == COMPLETED_ONBOARDING.player.description
+    # assert game_state.player.background == COMPLETED_ONBOARDING.player.background
+    # assert game_state.player.motivation == COMPLETED_ONBOARDING.player.motivation
+    # assert game_state.player.inventory == COMPLETED_ONBOARDING.player.inventory
+    #
+    # assert game_state.current_quest
+    # assert game_state.active_mode.value == ActiveMode.QUEST.value
 
 
 @pytest.mark.parametrize("invocable_handler", [AdventureGameService], indirect=True)

--- a/tests/steamship_tests/fixtures.py
+++ b/tests/steamship_tests/fixtures.py
@@ -10,7 +10,7 @@ from steamship.invocable import (
 )
 from steamship.invocable.invocable import Invocable
 from steamship.invocable.lambda_handler import create_safe_handler as _create_handler
-from steamship_tests.test_utils import get_steamship_client, random_name
+from test_utils import get_steamship_client, random_name
 
 
 @pytest.fixture()

--- a/tests/steamship_tests/fixtures.py
+++ b/tests/steamship_tests/fixtures.py
@@ -10,7 +10,7 @@ from steamship.invocable import (
 )
 from steamship.invocable.invocable import Invocable
 from steamship.invocable.lambda_handler import create_safe_handler as _create_handler
-from test_utils import get_steamship_client, random_name
+from steamship_tests.test_utils import get_steamship_client, random_name
 
 
 @pytest.fixture()

--- a/tests/steamship_tests/utils/test_generation_utils.py
+++ b/tests/steamship_tests/utils/test_generation_utils.py
@@ -1,3 +1,4 @@
+import toml
 from steamship import Block, File, Steamship, Tag
 from steamship.agents.schema import AgentContext
 from steamship.data.tags.tag_constants import ChatTag, RoleTag, TagKind, TagValueKey
@@ -160,7 +161,8 @@ def create_test_game_state(context: AgentContext) -> GameState:
 
 
 def run_onboarding(context: AgentContext):
-    agent = OnboardingAgent(tools=[])
+    secrets = toml.load("../../src/.steamship/secrets.toml")
+    agent = OnboardingAgent(tools=[], openai_api_key=secrets["openai_api_key"])
     try:
         agent.run(context)
     except RunNextAgentException:


### PR DESCRIPTION
- This PR seeks to speed up the complete_onboarding call:
    - Direct moderation
    - Lower waits for faux-streaming SDXL generations
    - caching plugin instance creation in SDXL generator wrapper
    - fewer use_plugin calls

Locally, this seems to take me from 20-25s to ~5s for onboarding.  The remaining time is predominantly in image gen initialization and the now much faster moderation.

Post this PR, you will need to have a `src/.steamship/secrets.toml` with the openai api key.