### PR TITLE
Use correct theme for quest scenes

### DIFF
--- a/src/agents/quest_agent.py
+++ b/src/agents/quest_agent.py
@@ -11,8 +11,8 @@ from steamship.agents.schema import Action, AgentContext
 from steamship.agents.schema.action import FinishAction
 
 from generators.generator_context_utils import (
-    get_camp_image_generator,
     get_music_generator,
+    get_quest_background_image_generator,
 )
 from schema.game_state import GameState
 from schema.quest import Quest, QuestDescription
@@ -349,7 +349,7 @@ class QuestAgent(InterruptiblePythonAgent):
         )
         updated_problem_block = await_streamed_block(problem_block, context)
 
-        if image_gen := get_camp_image_generator(context):
+        if image_gen := get_quest_background_image_generator(context):
             image_gen.request_scene_image_generation(
                 description=updated_problem_block.text, context=context
             )

--- a/src/api.py
+++ b/src/api.py
@@ -291,6 +291,14 @@ class GameREPL(AgentREPL):
 
         # Determine the responder, which may have been custom-supplied on the agent.
         responder = getattr(self.agent_instance, self.method or "prompt")
+        # Send first empty string
+        self.print_object_or_objects(
+            responder(prompt="", context_id=self.context_id, **kwargs)
+        )
+        # Skip camp agent and go on a quest
+        self.print_object_or_objects(
+            responder(prompt="Go on a quest", context_id=self.context_id, **kwargs)
+        )
         while True:
             input_text = input(colored(text="Input: ", color="blue"))  # noqa: F821
             output = responder(prompt=input_text, context_id=self.context_id, **kwargs)

--- a/src/generators/generator_context_utils.py
+++ b/src/generators/generator_context_utils.py
@@ -11,6 +11,7 @@ from generators.social_media_generator import SocialMediaGenerator
 from utils.context_utils import get_server_settings, get_theme
 
 _CAMP_IMAGE_GENERATOR_KEY = "camp-image-generator"
+_QUEST_BACKGROUND_IMAGE_GENERATOR_KEY = "quest-background-image-generator"
 _ITEM_IMAGE_GENERATOR_KEY = "item-image-generator"
 _PROFILE_IMAGE_GENERATOR_KEY = "profile-image-generator"
 _MUSIC_GENERATOR_KEY = "music-generator"
@@ -26,6 +27,19 @@ def get_camp_image_generator(context: AgentContext) -> Optional[ImageGenerator]:
         generator = get_image_generator(theme)
         context.metadata[_CAMP_IMAGE_GENERATOR_KEY] = generator
 
+    return generator
+
+
+def get_quest_background_image_generator(
+    context: AgentContext,
+) -> Optional[ImageGenerator]:
+    generator = context.metadata.get(_QUEST_BACKGROUND_IMAGE_GENERATOR_KEY)
+    if not generator:
+        # Lazily create
+        server_settings = get_server_settings(context)
+        theme = get_theme(server_settings.quest_background_theme, context)
+        generator = get_image_generator(theme)
+        context.metadata[_QUEST_BACKGROUND_IMAGE_GENERATOR_KEY] = generator
     return generator
 
 


### PR DESCRIPTION
Fix issue with different themes for camp image / quest scene not being respected.

Side bonus: skip initial two inputs when debugging locally.