### PR TITLE
Cascade failures on PluginInstance

### DIFF
--- a/src/generators/cascading_plugin.py
+++ b/src/generators/cascading_plugin.py
@@ -67,12 +67,7 @@ class CascadingPlugin(PluginInstance):
                 self._advance_instance()
 
     def train(self, *args, **kwargs):
-        while True:
-            try:
-                return self._current_instance().train(*args, **kwargs)
-            except Exception as e:
-                self._exception_map[self._current_instance().plugin_id] = e
-                self._advance_instance()
+        raise NotImplementedError("The `train` endpoint is not implemented for CascadingPlugin")
 
     def refresh_init_status(self, *args, **kwargs):
         while True:

--- a/src/generators/cascading_plugin.py
+++ b/src/generators/cascading_plugin.py
@@ -29,6 +29,9 @@ class CascadingPlugin(PluginInstance):
         self._instance_provider_ix += 1
         self._cached_instance = None
         if self._instance_provider_ix >= len(self.instance_providers):
+            # Don't make it so that this will never succeed again, let it recover on a basic heuristic.
+            # TODO this / current_instance could be smarter to try the preferred ones on a backoff
+            self._instance_provider_ix = 0
             raise ExhaustedPluginsException(self._exception_map)
 
     def _current_instance(self) -> PluginInstance:

--- a/src/generators/cascading_plugin.py
+++ b/src/generators/cascading_plugin.py
@@ -1,0 +1,88 @@
+from typing import Callable, Mapping, List, Dict, Optional
+
+from pydantic import PrivateAttr
+from steamship import PluginInstance
+
+InstanceProvider = Callable[[], PluginInstance]
+
+
+class ExhaustedPluginsException(Exception):
+    def __init__(self, exceptions: Mapping[str, Exception]):
+        self.exceptions = exceptions
+        message = []
+        for plugin_name, e in exceptions.items():
+            message.append(f"- {plugin_name}: {str(e)}\n")
+        message_str = f"Plugin calls exhausted with following exceptions:\n{''.join(message)}"
+        super().__init__(message_str)
+
+
+class CascadingPlugin(PluginInstance):
+    """
+    A PluginInstance wrapper which takes multiple providers of PluginInstances and cascades calls to them upon failure.
+    """
+    instance_providers: List[InstanceProvider]
+    _exception_map: Dict[str, Exception] = PrivateAttr(dict())
+    _instance_provider_ix: int = PrivateAttr(0)
+    _cached_instance: Optional[PluginInstance] = PrivateAttr(None)
+
+    def _advance_instance(self) -> None:
+        self._instance_provider_ix += 1
+        self._cached_instance = None
+        if self._instance_provider_ix >= len(self.instance_providers):
+            raise ExhaustedPluginsException(self._exception_map)
+
+    def _current_instance(self) -> PluginInstance:
+        if not self._cached_instance:
+            self._cached_instance = self.instance_providers[self._instance_provider_ix]()
+        return self._cached_instance
+
+    # The following methods are wrapping around the API for PluginInstance.
+    # TODO this could be hacked up in a more general sense to check for Callables and pass these through in getattr?
+
+    def tag(self, *args, **kwargs):
+        while True:
+            try:
+                return self._current_instance().tag(*args, **kwargs)
+            except Exception as e:
+                self._exception_map[self._current_instance().plugin_id] = e
+                self._advance_instance()
+
+    def generate(self, *args, **kwargs):
+        while True:
+            try:
+                return self._current_instance().generate(*args, **kwargs)
+            except Exception as e:
+                self._exception_map[self._current_instance().plugin_id] = e
+                self._advance_instance()
+
+    def delete(self, *args, **kwargs):
+        while True:
+            try:
+                return self._current_instance().delete(*args, **kwargs)
+            except Exception as e:
+                self._exception_map[self._current_instance().plugin_id] = e
+                self._advance_instance()
+
+    def train(self, *args, **kwargs):
+        while True:
+            try:
+                return self._current_instance().train(*args, **kwargs)
+            except Exception as e:
+                self._exception_map[self._current_instance().plugin_id] = e
+                self._advance_instance()
+
+    def refresh_init_status(self, *args, **kwargs):
+        while True:
+            try:
+                return self._current_instance().refresh_init_status(*args, **kwargs)
+            except Exception as e:
+                self._exception_map[self._current_instance().plugin_id] = e
+                self._advance_instance()
+
+    def wait_for_init(self, *args, **kwargs):
+        while True:
+            try:
+                return self._current_instance().wait_for_init(*args, **kwargs)
+            except Exception as e:
+                self._exception_map[self._current_instance().plugin_id] = e
+                self._advance_instance()

--- a/src/schema/server_settings.py
+++ b/src/schema/server_settings.py
@@ -319,6 +319,14 @@ class ServerSettings(BaseModel):
             },
         ],
     )
+
+    allow_backup_story_models: bool = SettingField(
+        default=False,
+        label="Allow backup story models",
+        description="If the primary model for stories is unavailable, allow falling back to other models.",
+        type="boolean"
+    )
+
     default_story_temperature: float = SettingField(
         # NEEDS WORK:
         # TODO: Add a post-processing step to coerce this to a float.

--- a/src/schema/server_settings_schema.py
+++ b/src/schema/server_settings_schema.py
@@ -66,6 +66,7 @@ STORY_OPTIONS = [
         "type": "divider",
     },
     s.default_story_model,
+    s.allow_backup_story_models,
     s.default_story_temperature,
     s.default_story_max_tokens,
 ]

--- a/src/utils/context_utils.py
+++ b/src/utils/context_utils.py
@@ -101,7 +101,9 @@ def get_story_text_generator(
             providers = [
                 lambda: generator
             ]
-            for backup_model_name in replicate_models:
+            for backup_model_name in open_ai_models:
+                if backup_model_name == model_name:
+                    continue
                 provider = lambda: context.client.use_plugin(
                     "replicate-llm",
                     config={

--- a/src/utils/context_utils.py
+++ b/src/utils/context_utils.py
@@ -105,7 +105,7 @@ def get_story_text_generator(
                 if backup_model_name == model_name:
                     continue
                 provider = lambda: context.client.use_plugin(
-                    "replicate-llm",
+                    "gpt-4",
                     config={
                         "model": backup_model_name,
                         "max_tokens": server_settings.default_story_max_tokens,

--- a/tests/steamship_tests/generators/test_cascading_plugin.py
+++ b/tests/steamship_tests/generators/test_cascading_plugin.py
@@ -1,0 +1,35 @@
+import pytest
+from steamship import PluginInstance, Block
+
+from generators.cascading_plugin import CascadingPlugin, ExhaustedPluginsException
+
+
+class DummyInstance(PluginInstance):
+    count: int = 0
+    throw: bool = False
+
+    def generate(self, *args, **kwargs):
+        if self.throw:
+            raise Exception(f"{self.count}")
+        self.count += 1
+        return Block(text=f"{self.plugin_id}_{self.count}")
+
+
+def test_cascade_with_failures():
+    instance_1 = DummyInstance(plugin_id="Instance1")
+    instance_2 = DummyInstance(plugin_id="Instance2")
+    providers = [
+        lambda: instance_1,
+        lambda: instance_2
+    ]
+
+    pi: PluginInstance = CascadingPlugin(instance_providers=providers)
+    assert pi.generate(text="First Call") == Block(text="Instance1_1")
+    assert pi.generate(text="Second Call") == Block(text="Instance1_2")
+    instance_1.throw = True
+    assert pi.generate(text="Third Call") == Block(text="Instance2_1")
+    assert pi.generate(text="Fourth Call") == Block(text="Instance2_2")
+    instance_2.throw = True
+    with pytest.raises(ExhaustedPluginsException) as e:
+        pi.generate(text="Fifth Call")
+        assert e.exceptions.keys() == set(list("Instance1", "Instance2"))

--- a/tests/steamship_tests/generators/test_cascading_plugin.py
+++ b/tests/steamship_tests/generators/test_cascading_plugin.py
@@ -32,4 +32,4 @@ def test_cascade_with_failures():
     instance_2.throw = True
     with pytest.raises(ExhaustedPluginsException) as e:
         pi.generate(text="Fifth Call")
-        assert e.exceptions.keys() == set(list("Instance1", "Instance2"))
+    assert e.value.exceptions.keys() == set(["Instance1", "Instance2"])

--- a/tests/steamship_tests/generators/test_cascading_plugin.py
+++ b/tests/steamship_tests/generators/test_cascading_plugin.py
@@ -33,3 +33,6 @@ def test_cascade_with_failures():
     with pytest.raises(ExhaustedPluginsException) as e:
         pi.generate(text="Fifth Call")
     assert e.value.exceptions.keys() == set(["Instance1", "Instance2"])
+    # Test that we can still generate after that
+    instance_1.throw = False
+    assert pi.generate(text="Sixth Call") == Block(text="Instance1_3")


### PR DESCRIPTION
An implementation wrapping PluginInstance which can fall back to other PluginInstances when Exceptions come out.

- WIP: Wrap this into config so that there's a cascading list of providers for plugin interfaces
- Optionally, wrap that around so that it stores in GameState and can keep track of what the currently used plugin is