### PR TITLE
add visualDescription field to Items

### DIFF
--- a/src/generators/image_generators/dalle.py
+++ b/src/generators/image_generators/dalle.py
@@ -94,6 +94,7 @@ class DalleImageGenerator(ImageGenerator):
                 "tone": server_settings.narrative_tone,
                 "name": item.name,
                 "description": item.description,
+                "visual_description": item.visual_description,
             },
             image_size="1024x1024",
             tags=tags,

--- a/src/generators/image_generators/stable_diffusion_with_loras.py
+++ b/src/generators/image_generators/stable_diffusion_with_loras.py
@@ -114,6 +114,7 @@ class StableDiffusionWithLorasImageGenerator(ImageGenerator):
                 "name": item.name,
                 "genre": server_settings.narrative_voice,
                 "description": item.description,
+                "visual_description": item.visual_description,
             },
             image_size="square_hd",
             tags=tags,

--- a/src/schema/objects.py
+++ b/src/schema/objects.py
@@ -7,6 +7,7 @@ from pydantic import BaseModel, Field
 class Item(BaseModel):
     name: Optional[str]
     description: Optional[str]
+    visual_description: Optional[str]
     id: str = Field(default_factory=lambda: str(uuid4()))
 
     is_one_time_use: Optional[bool]

--- a/src/schema/server_settings.py
+++ b/src/schema/server_settings.py
@@ -324,7 +324,7 @@ class ServerSettings(BaseModel):
         default=False,
         label="Allow backup story models",
         description="If the primary model for stories is unavailable, allow falling back to other models.",
-        type="boolean"
+        type="boolean",
     )
 
     default_story_temperature: float = SettingField(
@@ -661,10 +661,11 @@ Can include descriptions of genre, characters, specific items and locations that
         label="Item Image Prompt",
         description="The prompt used to generate item images.",
         type="longtext",
-        default="game sprite for an {name}, {description}",
+        default="game sprite for an {name}, {visual_description}",
         variables_permitted={
             "name": "The name of the item.",
             "description": "Description of the item.",
+            "visual_description": "A purely visual description of the item.",
             "tone": "Description of the tone of the adventure.",
             "genre": "Description of the genre of the adventure.",
         },

--- a/src/tools/end_quest_tool.py
+++ b/src/tools/end_quest_tool.py
@@ -108,13 +108,16 @@ class EndQuestTool(Tool):
                         context.chat_history.file.refresh()
                         item.picture_url = item_image_block.raw_data_url
             else:
-                item_name, item_description = generate_quest_item(
-                    quest.name, player, context
-                )
+                (
+                    item_name,
+                    item_description,
+                    item_visual_description,
+                ) = generate_quest_item(quest.name, player, context)
 
                 item = Item()
                 item.name = item_name
                 item.description = item_description
+                item.visual_description = item_visual_description
 
                 if item.name:
                     new_items.append(item)

--- a/src/utils/generation_utils.py
+++ b/src/utils/generation_utils.py
@@ -10,6 +10,7 @@ While at the same time not committing to any huge abstraction overhead: this is 
 functions whose mechanics can change under the hood as we discover better ways to do things, and the game developer
 doesn't need to know.
 """
+import json
 import logging
 import time
 from typing import List, Optional, Tuple
@@ -203,9 +204,19 @@ def generate_quest_summary(
 
 def generate_quest_item(
     quest_name: str, player: HumanCharacter, context: AgentContext
-) -> (str, str):
+) -> (str, str, str):
     """Generates a found item from a quest, returning a tuple of its name and description"""
-    prompt = f"What item did {player.name} find during that story? It should fit the setting of the story and help {player.name} achieve their goal. Please respond only with ITEM NAME: <name> ITEM DESCRIPTION: <description>"
+    prompt = (
+        f"What item did {player.name} find during that story? It should fit the setting of the story and "
+        f"help {player.name} achieve their goal. Please respond only with valid JSON that includes the following "
+        f"fields: 'name', 'description', 'visualDescription'\n"
+        f"Example:\n"
+        '{"name": "Loaf of Italian Bread", '
+        '"description": "A freshly baked, fluffy loaf of Italian bread, with a golden crust and a soft, airy interior. Ideal for heroically hiding a seasoned meatball from the sharp edge of a sous-chef\'s knife. The bread\'s cavernous insides provided the perfect escape tunnel for Mr. Meatball to avoid becoming part of the next culinary creation.", '
+        '"visualDescription": "A freshly baked, fluffy loaf of Italian bread, with a golden crust and a soft, airy interior."'
+        "}\n"
+        "Return ONLY JSON."
+    )
     block = do_token_trimmed_generation(
         context,
         prompt,
@@ -223,14 +234,11 @@ def generate_quest_item(
         generation_for="Quest Item",
         streaming=False,
     )
-    parts = block.text.split("ITEM DESCRIPTION:")
-    if len(parts) == 2:
-        name = parts[0].replace("ITEM NAME:", "").strip()
-        description = parts[1].strip()
-    else:
-        name = block.text.strip()
-        description = ""
-    return name, description
+
+    json_block_text = block.text
+    tidy_json = json_block_text.replace("```json", "").replace("```", "")
+    item_json = json.loads(tidy_json.strip())
+    return item_json["name"], item_json["description"], item_json["visualDescription"]
 
 
 def generate_merchant_inventory(


### PR DESCRIPTION
There was an outstanding request for removing some of the non-visual bits of description in the item image generation prompts.